### PR TITLE
c-spinner containerless

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -24,7 +24,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         state="${link.isActive ? 'active' : ''}"
                     >
                     </c-nav-horizontal-item>
-                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.0.10"></c-nav-horizontal-item>
+                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.0.11"></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>
         </l-sidebar>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/utilities/c-spinner/c-spinner.ts
+++ b/src/components/utilities/c-spinner/c-spinner.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './c-spinner.css.json';
 
-@containerless
 export class CSpinner {
     @bindable
     public size = 'medium';


### PR DESCRIPTION
### Problem
Using containerless takes the component tag name out of the DOM. It can be useful in some cases but it makes it harder for AU to track the state and what not of the component. We need to remove containerless from the c-spinner

### Solution
Remove containerless from c-spinner