### PR TITLE
add optional help tip in modal header

### DIFF
--- a/dev-app/routes/components/modal/modal.html
+++ b/dev-app/routes/components/modal/modal.html
@@ -39,6 +39,7 @@ export class modal {
             viewModel: PLATFORM.moduleName('resources/components/modal/c-modal/c-modal'),
             model: {
                 title: 'Hi',
+                titleHelp: 'Help text here',
                 size: 'medium',
                 bodyText: 'Modal Body',
                 bodyViewModel: PLATFORM.moduleName('/routes/components/modal/body'),

--- a/dev-app/routes/components/modal/modal.ts
+++ b/dev-app/routes/components/modal/modal.ts
@@ -38,6 +38,7 @@ export class Modal {
         {
             description: 'If you just need text in your modal you can place it here in a string.',
             option: 'bodyText',
+            value: 'string',
         },
         {
             description:
@@ -52,6 +53,7 @@ export class Modal {
         {
             description: 'If you only need text in your footer you can put it here in a string.',
             option: 'footerText',
+            value: 'string',
         },
         {
             description: 'If you need to pass anything out of your template you can add it here.',
@@ -72,6 +74,12 @@ export class Modal {
         {
             description: 'Set what will be displayed as the title of the modal.',
             option: 'title',
+            value: 'string',
+        },
+        {
+            description: 'Set if you need a help tip next to the title of the modal',
+            option: 'titleHelp',
+            value: 'string',
         },
     ];
 
@@ -153,6 +161,7 @@ export class Modal {
                 footerViewModel: PLATFORM.moduleName('routes/components/modal/footer'),
                 size: 'auto',
                 title: 'Hi',
+                titleHelp: 'Help text here.',
             },
             viewModel: PLATFORM.moduleName('resources/components/modal/c-modal/c-modal'),
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/modal/c-modal/c-modal.html
+++ b/src/components/modal/c-modal/c-modal.html
@@ -13,18 +13,53 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         ${model.size == 'large' ? 'js-large' : ''}
     ">
         <ux-dialog-header class="${styles.header}">
-            <c-h2>${model.title}</c-h2>
-            <c-button click.delegate="controller.cancel()" class="${styles.closeButton}" icon="x" icon-position="center"></c-button>
+            <l-cluster
+                spacing="var(--s-1)"
+                spacing-direction="right"
+                align="flex-start"
+            >
+                <div>
+                    <c-h2>${model.title}</c-h2>
+                    <c-tip
+                        side="right"
+                        size="large"
+                        icon-tip.bind="true"
+                        if.bind="model.titleHelp"
+                    >
+                        <div slot="trigger">
+                            <c-icon icon="question"></c-icon>
+                        </div>
+                        <div slot="content">
+                            <c-p color="var(--c_white)">${model.titleHelp}</c-p>
+                        </div>
+                    </c-tip>
+                </div>
+            </l-cluster>
+            <c-button
+                click.delegate="controller.cancel()"
+                class="${styles.closeButton}"
+                icon="x"
+                icon-position="center"
+            ></c-button>
         </ux-dialog-header>
-
-        <ux-dialog-body class="${styles.body}" if.bind="model.bodyText || model.bodyViewModel">
+        <ux-dialog-body
+            class="${styles.body}"
+            if.bind="model.bodyText || model.bodyViewModel"
+        >
             <c-p if.bind="!model.bodyViewModel">${model.bodyText}</c-p>
-            <compose if.bind="model.bodyViewModel" view-model.bind="model.bodyViewModel" model.bind="{body: model.bodyModel, controller: controller, shared: model.sharedModel}"></compose>
+            <compose
+                if.bind="model.bodyViewModel"
+                view-model.bind="model.bodyViewModel"
+                model.bind="{body: model.bodyModel, controller: controller, shared: model.sharedModel}"
+            ></compose>
         </ux-dialog-body>
-
         <ux-dialog-footer if.bind="model.footerEnable">
             <c-p if.bind="!model.footerViewModel">${model.footerText}</c-p>
-            <compose if.bind="model.footerViewModel" view-model.bind="model.footerViewModel" model.bind="{footer: model.footerModel, controller: controller, shared: model.sharedModel}"></compose>
+            <compose
+                if.bind="model.footerViewModel"
+                view-model.bind="model.footerViewModel"
+                model.bind="{footer: model.footerModel, controller: controller, shared: model.sharedModel}"
+            ></compose>
         </ux-dialog-footer>
     </ux-dialog>
 </template>

--- a/src/components/modal/c-modal/c-modal.ts
+++ b/src/components/modal/c-modal/c-modal.ts
@@ -40,7 +40,6 @@ export class CModal {
             .parent()
             .parent()
             .css('width', '100%');
-
         $('ux-dialog.js-large')
             .parent()
             .css('height', '100%');


### PR DESCRIPTION
### Problem
If you'd like to add a c-tip to be next to the title of a modal you can't currently.

### Solution
Allow for an optional tip to be placed next to the modal header and allow for custom text content in that tip.