### PR TITLE
Table row disabled

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -24,7 +24,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         state="${link.isActive ? 'active' : ''}"
                     >
                     </c-nav-horizontal-item>
-                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.0.20"></c-nav-horizontal-item>
+                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.0.21"></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>
         </l-sidebar>

--- a/dev-app/routes/components/tables/table/actions/index.html
+++ b/dev-app/routes/components/tables/table/actions/index.html
@@ -28,6 +28,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         <li>bgProcess</li>
                         <li>healthy</li>
                         <li>info</li>
+                        <li>notAllowed</li>
                         <li>warning</li>
                         <li>critical</li>
                         <li>neutral</li>
@@ -123,7 +124,7 @@ tableActionsSample2 = {
     },
 };</c-code>
     <c-code-sample>
-        <c-table actions.bind="tableActionsSample1" cols.bind="basicCols" rows.bind="basicData"></c-table>
+        <c-table hover.bind="true" actions.bind="tableActionsSample1" cols.bind="basicCols" rows.bind="basicData"></c-table>
     </c-code-sample>
 
     <c-code-sample>

--- a/dev-app/routes/components/tables/table/actions/index.ts
+++ b/dev-app/routes/components/tables/table/actions/index.ts
@@ -19,6 +19,11 @@ export class TableActions {
             if (row.name && row.name === 'Fin') {
                 cls += ' bgInfo';
             }
+
+            if (row.name && row.name === 'Han Solo') {
+                cls += ' notAllowed';
+            }
+
             return cls;
         },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/tables/c-table/c-table.css
+++ b/src/components/tables/c-table/c-table.css
@@ -13,6 +13,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
  *      - Header
  *  STRIPED
  *  ROW HOVER
+ *  ROW NOT ALLOWED
  *  ROW ACTIVE
  *  NO VERTICAL BORDER
  *  CELL WIDTHS
@@ -116,6 +117,17 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     cursor: pointer;
 }
 
+
+
+
+
+/*------------------------------------*\
+    !ROW NOT ALLOWED
+\*------------------------------------*/
+
+.not-allowed:hover{
+    cursor: not-allowed !important;
+}
 
 
 

--- a/src/components/tables/c-table/c-table.css
+++ b/src/components/tables/c-table/c-table.css
@@ -132,6 +132,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 
 
+
 /*------------------------------------*\
     !ROW ACTIVE
 \*------------------------------------*/

--- a/src/components/tables/c-table/c-table.test.ts
+++ b/src/components/tables/c-table/c-table.test.ts
@@ -448,7 +448,7 @@ describe('c-table component', () => {
             });
 
             // Background Tests
-            const existingBackgroundClasses = ['bgHealthy', 'bgWarning', 'bgCritical', 'bgInfo'];
+            const existingBackgroundClasses = ['bgHealthy', 'bgWarning', 'bgCritical', 'bgInfo', 'notAllowed'];
             existingBackgroundClasses.forEach(background => {
                 it(`css class: ${background}`, async done => {
                     component = StageComponent.withResources().inView('<c-table></c-table>');


### PR DESCRIPTION
### Problem
If a table row needs to be seen but the user isn't allowed to click on it there is no visual indication of that.

### Solution
Add a `notAllowed` option to be passed to the table row to show the user on hover that it can't be interacted with.