### PR TITLE
Remove containerless

### DIFF
--- a/dev-app/routes/components/copy/slots/index.html
+++ b/dev-app/routes/components/copy/slots/index.html
@@ -24,8 +24,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     >
                         <span slot="tip">
                             <c-tip side="top" icon-tip.bind="true" arrow-position="leftEdge" size="medium">
-                                <div slot="trigger"><c-icon icon="question"></c-icon></div>
-                                <div slot="content">Content Here. Huzzah! that is a bit longer just to test</div>
+                                <div slot="trigger">
+                                    <c-icon icon="question"></c-icon>
+                                </div>
+                                <div slot="content"><c-p color="white">Content Here. Huzzah! that is a bit longer just to test</c-p></div>
                             </c-tip>
                         </span>
                     </c-copy>

--- a/dev-app/routes/components/forms/add-remove/actions/index.ts
+++ b/dev-app/routes/components/forms/add-remove/actions/index.ts
@@ -25,14 +25,14 @@ export class AddRemoveActions {
 
     public addRemoveActions = [
         {
-            description: 'Set a function to fire when the select contents changes on the left side.',
+            description: 'An object with callback functions. More details coming soon.',
             name: 'actions-left',
-            value: 'function',
+            value: 'object',
         },
         {
-            description: 'Set a function to fire when the select contents changes on the right side.',
+            description: 'An object with callback functions. More details coming soon.',
             name: 'actions-right',
-            value: 'function',
+            value: 'object',
         },
     ];
 }

--- a/dev-app/routes/components/forms/add-remove/properties/index.html
+++ b/dev-app/routes/components/forms/add-remove/properties/index.html
@@ -30,6 +30,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     ></c-form-add-remove>
                 </c-code-sample>
             </l-stack>
+            <br><br><br>
         </div>
 
         <c-divider></c-divider>
@@ -49,6 +50,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     ></c-form-add-remove>
                 </c-code-sample>
             </l-stack>
+            <br><br><br>
         </div>
 
         <c-divider></c-divider>
@@ -66,7 +68,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     ></c-form-add-remove>
                 </c-code-sample>
             </l-stack>
-            <br>
+            <br><br><br>
         </div>
 
         <c-divider></c-divider>

--- a/dev-app/routes/components/forms/add-remove/properties/index.html
+++ b/dev-app/routes/components/forms/add-remove/properties/index.html
@@ -30,7 +30,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     ></c-form-add-remove>
                 </c-code-sample>
             </l-stack>
-            <br>
         </div>
 
         <c-divider></c-divider>
@@ -50,7 +49,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     ></c-form-add-remove>
                 </c-code-sample>
             </l-stack>
-            <br>
         </div>
 
         <c-divider></c-divider>

--- a/dev-app/routes/components/forms/date/actions/index.ts
+++ b/dev-app/routes/components/forms/date/actions/index.ts
@@ -25,7 +25,7 @@ export class DateInputActions {
 
     public formDateOptionsActions = [
         {
-            description: 'An object of callbacks.',
+            description: 'An object with callback functions. More details coming soon.',
             name: 'callbacks',
             value: 'object',
         },

--- a/dev-app/routes/components/forms/date/properties/index.html
+++ b/dev-app/routes/components/forms/date/properties/index.html
@@ -38,7 +38,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         <div>
                             <c-form-date
                                 id="test31"
-                                label="Error"
+                                label="Icon"
                                 label-icon="info"
                                 error-msg="Date is required"
                             ></c-form-date>

--- a/dev-app/routes/components/forms/select/actions/index.html
+++ b/dev-app/routes/components/forms/select/actions/index.html
@@ -22,9 +22,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 };</c-code>
                 <c-code-sample>
                     <l-grid min-size="25ch">
+                        <l-stack>
                         <c-form-select select-value.bind="vSelectOutput" options.bind="testOptions" label="Select Label" error-msg="This is an error" actions.bind="testActions"></c-form-select>
+                        <c-p>select: ${vSelectOutput}</c-p>
+                        </l-stack>
                     </l-grid>
-                    <c-p>select: ${vSelectOutput}</c-p>
                 </c-code-sample>
             </l-stack>
         </div>

--- a/dev-app/routes/components/forms/select/actions/index.ts
+++ b/dev-app/routes/components/forms/select/actions/index.ts
@@ -21,19 +21,13 @@ export class SelectActions {
             colHeadName: 'description',
             colHeadValue: 'Description',
         },
-        {
-            _class: 'monospaced',
-            colClass: 't85',
-            colHeadName: 'default',
-            colHeadValue: 'Default',
-        },
     ];
 
     public formSelectActions = [
         {
-            description: 'Set a function to fire when the select contents changes.',
+            description: 'An object with callback functions. More details coming soon.',
             name: 'actions',
-            value: 'function',
+            value: 'object',
         },
     ];
 

--- a/dev-app/routes/components/forms/select/properties/index.html
+++ b/dev-app/routes/components/forms/select/properties/index.html
@@ -60,11 +60,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     }];
 }</c-code>
                 <c-code-sample>
-                    <l-grid min-size="25ch">
-                        <c-form-select select-value.bind="vSelectOutput" options.bind="testOptions" label="Select Label" error-msg="This is an error"></c-form-select>
-                        <c-form-select options.bind="testOptions" error-msg="This is an error"></c-form-select>
-                    </l-grid>
-                    <c-p>select: ${vSelectOutput}</c-p>
+                    <l-stack spacing="var(--s0)">
+                        <l-grid min-size="25ch">
+                            <c-form-select select-value.bind="vSelectOutput" options.bind="testOptions" label="Select Label" error-msg="This is an error"></c-form-select>
+                            <c-form-select options.bind="testOptions" error-msg="This is an error"></c-form-select>
+                        </l-grid>
+                        <c-p>select: ${vSelectOutput}</c-p>
+                    </l-stack>
                 </c-code-sample>
             </l-stack>
         </div>

--- a/dev-app/routes/components/timeline/properties/index.ts
+++ b/dev-app/routes/components/timeline/properties/index.ts
@@ -15,6 +15,7 @@ export class TimelineProperties {
         },
         {
             _class: 'monospaced',
+            colClass: 't270',
             colHeadName: 'type',
             colHeadValue: 'Type',
         },
@@ -24,6 +25,7 @@ export class TimelineProperties {
         },
         {
             _class: 'monospaced',
+            colClass: 't150',
             colHeadName: 'default',
             colHeadValue: 'Default',
         },

--- a/dev-app/routes/components/tip/actions/index.ts
+++ b/dev-app/routes/components/tip/actions/index.ts
@@ -34,10 +34,9 @@ export class TipActions {
 
     public tipActions = [
         {
-            default: '',
-            description: 'Callback functions supported: onHide, onShow. See actions section below for examples.',
+            description: 'An object with callback functions. Functions supported: onHide, onShow. See actions section below for examples.',
             name: 'actions',
-            value: 'Object with callback functions.',
+            value: 'object',
         },
     ];
 

--- a/dev-app/routes/components/type/headlines/index.html
+++ b/dev-app/routes/components/type/headlines/index.html
@@ -13,6 +13,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 <c-code-sample>
                     <c-h1 flush-top.bind="false">Not flush on the top</c-h1>
                     <c-h1>Normal Headline 1</c-h1>
+                    <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the end of the line or something. Shrink the width of the browser window if needed.</c-h1>
                     <l-cluster
                         align="flex-start"
                         justify="space-between"
@@ -25,6 +26,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                 spacing="var(--s-3)"
                                 spacing-direction="right"
                                 truncated-content.bind="true"
+                                style="width: 100%"
                             >
                                 <div>
                                     <c-icon

--- a/dev-app/routes/layouts/box-link/index.html
+++ b/dev-app/routes/layouts/box-link/index.html
@@ -59,6 +59,29 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
             <div>
                 <l-stack spacing="var(--s-3)">
+                    <c-h3>fill-space</c-h3>
+                    <c-code-sample>
+                        <l-grid>
+                            <l-box-link fill-space.bind="true">
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                            </l-box-link>
+                            <l-box-link fill-space.bind="true">
+                                <c-p>Single line yet the same height.</c-p>
+                            </l-box-link>
+                            <l-box-link fill-space.bind="false">
+                                <c-p>fill-space set to false</c-p>
+                            </l-box-link>
+                        </l-grid>
+                    </c-code-sample>
+                </l-stack>
+            </div>
+
+            <c-divider></c-divider>
+
+            <div>
+                <l-stack spacing="var(--s-3)">
                     <c-h3>margin-sides &amp; margin-ends</c-h3>
                     <c-code-sample>
                         <l-stack>

--- a/dev-app/routes/layouts/box-link/index.ts
+++ b/dev-app/routes/layouts/box-link/index.ts
@@ -53,6 +53,12 @@ export class BoxLinkProperties {
             value: 'Any color value. It is advised that you use the Core Color CSS Properties.',
         },
         {
+            default: 'false',
+            description: 'Set to true if you want height: 100% set on the box.',
+            name: 'fill-space',
+            value: 'boolean',
+        },
+        {
             default: '#',
             description: 'Set the URL where the link should go.',
             name: 'href',

--- a/dev-app/routes/layouts/box/index.html
+++ b/dev-app/routes/layouts/box/index.html
@@ -57,6 +57,29 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
             <div>
                 <l-stack spacing="var(--s-3)">
+                    <c-h3>fill-space</c-h3>
+                    <c-code-sample>
+                        <l-grid>
+                            <l-box fill-space.bind="true">
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                                <c-p>I am a tall box with muiltiple lines.</c-p>
+                            </l-box>
+                            <l-box fill-space.bind="true">
+                                <c-p>Single line yet the same height.</c-p>
+                            </l-box>
+                            <l-box fill-space.bind="false">
+                                <c-p>fill-space set to false</c-p>
+                            </l-box>
+                        </l-grid>
+                    </c-code-sample>
+                </l-stack>
+            </div>
+
+            <c-divider></c-divider>
+
+            <div>
+                <l-stack spacing="var(--s-3)">
                     <c-h3>margin-sides &amp; margin-ends</c-h3>
                     <c-code-sample>
                         <l-stack>

--- a/dev-app/routes/layouts/box/index.ts
+++ b/dev-app/routes/layouts/box/index.ts
@@ -47,6 +47,12 @@ export class BoxProperties {
             value: 'Any color value. It is advised that you use the Core Color CSS Properties.',
         },
         {
+            default: 'false',
+            description: 'Set to true if you want height: 100% set on the box.',
+            name: 'fill-space',
+            value: 'boolean',
+        },
+        {
             default: '0px',
             description: 'Set the left and right margin of the box.',
             name: 'margin-sides',

--- a/dev-app/routes/layouts/grid/methods/index.ts
+++ b/dev-app/routes/layouts/grid/methods/index.ts
@@ -21,24 +21,13 @@ export class GridMethods {
             colHeadName: 'description',
             colHeadValue: 'Description',
         },
-        {
-            _class: 'monospaced',
-            colHeadName: 'default',
-            colHeadValue: 'Default',
-        },
     ];
 
     public gridMethods = [
         {
-            description: 'The function you want to run when the button is clicked.',
-            name: 'action',
-            value: 'function',
-        },
-        {
-            default: '_self',
-            description: 'Set if you want the box link to open in a new window.',
-            name: 'target',
-            value: '_self | _blank',
+            description: 'An object with callback functions. More details coming soon.',
+            name: 'actions',
+            value: 'object',
         },
     ];
 

--- a/dev-app/routes/layouts/grid/properties/index.html
+++ b/dev-app/routes/layouts/grid/properties/index.html
@@ -52,21 +52,22 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h3>gap</c-h3>
                 <c-code-sample>
-                    <l-grid gap="var(--s5)">
-                        <l-box>First Item</l-box>
-                        <l-box>Second Item</l-box>
-                        <l-box>Third Item</l-box>
-                        <l-box>Fourth Item</l-box>
-                        <l-box>Fifth Item</l-box>
-                    </l-grid>
-
-                    <l-grid gap="0px">
-                        <l-box>First Item</l-box>
-                        <l-box>Second Item</l-box>
-                        <l-box>Third Item</l-box>
-                        <l-box>Fourth Item</l-box>
-                        <l-box>Fifth Item</l-box>
-                    </l-grid>
+                    <l-stack>
+                        <l-grid gap="var(--s5)">
+                            <l-box>First Item</l-box>
+                            <l-box>Second Item</l-box>
+                            <l-box>Third Item</l-box>
+                            <l-box>Fourth Item</l-box>
+                            <l-box>Fifth Item</l-box>
+                        </l-grid>
+                        <l-grid gap="0px">
+                            <l-box>First Item</l-box>
+                            <l-box>Second Item</l-box>
+                            <l-box>Third Item</l-box>
+                            <l-box>Fourth Item</l-box>
+                            <l-box>Fifth Item</l-box>
+                        </l-grid>
+                    </l-stack>
                 </c-code-sample>
             </l-stack>
         </div>
@@ -77,15 +78,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h3>auto-sizing</c-h3>
                 <c-code-sample>
-                    <l-grid>
-                        <l-box>First Item</l-box>
-                        <l-box>Second Item</l-box>
-                    </l-grid>
-
-                    <l-grid auto-sizing="auto-fill">
-                        <l-box>First Item</l-box>
-                        <l-box>Second Item</l-box>
-                    </l-grid>
+                    <l-stack>
+                        <l-grid>
+                            <l-box>First Item</l-box>
+                            <l-box>Second Item</l-box>
+                        </l-grid>
+                        <l-grid auto-sizing="auto-fill">
+                            <l-box>First Item</l-box>
+                            <l-box>Second Item</l-box>
+                        </l-grid>
+                    </l-stack>
                 </c-code-sample>
             </l-stack>
         </div>

--- a/dev-app/routes/layouts/stack/index.html
+++ b/dev-app/routes/layouts/stack/index.html
@@ -118,7 +118,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
             <c-divider></c-divider>
 
-            <div>
+            <div style="height: 500px;">
                 <l-stack spacing="var(--s-3)">
                     <c-h3>Split After</c-h3>
                     <c-code-sample class="example">

--- a/dev-app/routes/layouts/switcher/index.html
+++ b/dev-app/routes/layouts/switcher/index.html
@@ -38,7 +38,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-divider></c-divider>
 
             <div>
-                <l-stack spacing="var(-s-3)">
+                <l-stack spacing="var(--s-3)">
                     <c-h3>double-width</c-h3>
                     <c-code-sample>
                         <l-switcher double-width="second">
@@ -53,7 +53,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-divider></c-divider>
 
             <div>
-                <l-stack spacing="var(-s-3)">
+                <l-stack spacing="var(--s-3)">
                     <c-h3>limit</c-h3>
                     <c-code-sample>
                         <l-switcher limit="three">
@@ -69,20 +69,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-divider></c-divider>
 
             <div>
-                <l-stack spacing="var(-s-3)">
+                <l-stack spacing="var(--s-3)">
                     <c-h3>spacing</c-h3>
                     <c-code-sample>
-                        <l-switcher spacing="var(--s5)">
-                            <l-box>First Item</l-box>
-                            <l-box>Second Item</l-box>
-                            <l-box>Third Item</l-box>
-                        </l-switcher>
-
-                        <l-switcher spacing="0px">
-                            <l-box>First Item</l-box>
-                            <l-box>Second Item</l-box>
-                            <l-box>Third Item</l-box>
-                        </l-switcher>
+                        <l-stack>
+                            <l-switcher spacing="var(--s5)">
+                                <l-box>First Item</l-box>
+                                <l-box>Second Item</l-box>
+                                <l-box>Third Item</l-box>
+                            </l-switcher>
+                            <l-switcher spacing="0px">
+                                <l-box>First Item</l-box>
+                                <l-box>Second Item</l-box>
+                                <l-box>Third Item</l-box>
+                            </l-switcher>
+                        </l-stack>
                     </c-code-sample>
                 </l-stack>
             </div>
@@ -90,7 +91,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-divider></c-divider>
 
             <div>
-                <l-stack spacing="var(-s-3)">
+                <l-stack spacing="var(--s-3)">
                     <c-h3>threshold</c-h3>
                     <c-code-sample>
                         <l-stack>
@@ -99,13 +100,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                 <l-box>Second Item</l-box>
                                 <l-box>Third Item</l-box>
                             </l-switcher>
-
                             <l-switcher threshold="50rem">
                                 <l-box>First Item</l-box>
                                 <l-box>Second Item</l-box>
                                 <l-box>Third Item</l-box>
                             </l-switcher>
-
                             <l-switcher threshold="60rem">
                                 <l-box>First Item</l-box>
                                 <l-box>Second Item</l-box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/buttons/c-button/c-button.html
+++ b/src/components/buttons/c-button/c-button.html
@@ -8,7 +8,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <button
         disabled.bind="_state === 'thinking' || _state === 'disabled'"
-        class="${styles.button}  ${styles[color]}  ${styles[size]}  ${styles[_state]}  ${icon ? styles.icon : ''}  ${styles[iconPosition]}"
+        class="
+            ${styles.button}
+            ${styles[color]}
+            ${styles[size]}
+            ${styles[_state]}
+            ${icon ? styles.icon : ''}
+            ${styles[iconPosition]}
+        "
         click.trigger="actionFunction()"
         type="${type}"
         hide.bind="title || _state === 'hidden'"
@@ -26,7 +33,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     <a
         href.bind="href"
         target="${targetNew ? '_blank' : '_self'}"
-        class="${styles.button}  ${styles[color]}  ${styles[size]}  ${styles[_state]}  ${icon ? styles.icon : ''}  ${styles[iconPosition]}"
+        class="
+            ${styles.button}
+            ${styles[color]}
+            ${styles[size]}
+            ${styles[_state]}
+            ${icon ? styles.icon : ''}
+            ${styles[iconPosition]}
+        "
         if.bind="title && _state !== 'hidden'"
     >
         <c-icon

--- a/src/components/buttons/c-button/c-button.html
+++ b/src/components/buttons/c-button/c-button.html
@@ -8,19 +8,35 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <button
         disabled.bind="_state === 'thinking' || _state === 'disabled'"
-        hide.bind="title || _state === 'hidden'"
         class="${styles.button}  ${styles[color]}  ${styles[size]}  ${styles[_state]}  ${icon ? styles.icon : ''}  ${styles[iconPosition]}"
         click.trigger="actionFunction()"
         type="${type}"
+        hide.bind="title || _state === 'hidden'"
     >
-        <c-icon if.bind="showLeftIcon()" icon="${icon}"></c-icon>
+        <c-icon
+            icon="${icon}"
+            if.bind="showLeftIcon()"
+        ></c-icon>
         <slot></slot>
-        <c-icon if.bind="showRightOrCenterIcon()" icon="${icon}"></c-icon>
+        <c-icon
+            if.bind="showRightOrCenterIcon()"
+            icon="${icon}"
+        ></c-icon>
     </button>
-
-    <a href.bind="href" if.bind="title && _state !== 'hidden'" target="${targetNew ? '_blank' : '_self'}" class="${styles.button}  ${styles[color]}  ${styles[size]}  ${styles[_state]}  ${icon ? styles.icon : ''}  ${styles[iconPosition]}">
-        <c-icon if.bind="showLeftIcon()" icon="${icon}"></c-icon>
+    <a
+        href.bind="href"
+        target="${targetNew ? '_blank' : '_self'}"
+        class="${styles.button}  ${styles[color]}  ${styles[size]}  ${styles[_state]}  ${icon ? styles.icon : ''}  ${styles[iconPosition]}"
+        if.bind="title && _state !== 'hidden'"
+    >
+        <c-icon
+            if.bind="showLeftIcon()"
+            icon="${icon}"
+        ></c-icon>
         ${title}
-        <c-icon if.bind="showRightOrCenterIcon()" icon="${icon}"></c-icon>
+        <c-icon
+            if.bind="showRightOrCenterIcon()"
+            icon="${icon}"
+        ></c-icon>
     </a>
 </template>

--- a/src/components/copy/c-copy/c-copy.html
+++ b/src/components/copy/c-copy/c-copy.html
@@ -17,8 +17,19 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <div class="${styles.content}  ${wrap ? styles.wrap : ''}  ${!link ? '' : styles.hide}">
                 ${content}
             </div>
-            <a class="${styles.content}  ${wrap ? styles.wrap : ''}  ${link ? '' : styles.hide}" href="${content}" target="_blank">${content}</a>
-            <c-button color="neutral" click.delegate="copy(content)">Copy</c-button>
+            <a
+                class="${styles.content}  ${wrap ? styles.wrap : ''}  ${link ? '' : styles.hide}"
+                href="${content}"
+                target="_blank"
+            >
+                ${content}
+            </a>
+            <c-button
+                color="neutral"
+                click.delegate="copy(content)"
+            >
+                Copy
+            </c-button>
         </div>
     </div>
 </template>

--- a/src/components/copy/c-copy/c-copy.html
+++ b/src/components/copy/c-copy/c-copy.html
@@ -14,11 +14,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <slot name="tip"></slot>
         </div>
         <div class="${styles.container}">
-            <div class="${styles.content}  ${wrap ? styles.wrap : ''}  ${!link ? '' : styles.hide}">
+            <div
+                class="
+                    ${styles.content}
+                    ${wrap ? styles.wrap : ''}
+                    ${!link ? '' : styles.hide}
+                "
+            >
                 ${content}
             </div>
             <a
-                class="${styles.content}  ${wrap ? styles.wrap : ''}  ${link ? '' : styles.hide}"
+                class="
+                    ${styles.content}
+                    ${wrap ? styles.wrap : ''}
+                    ${link ? '' : styles.hide}
+                "
                 href="${content}"
                 target="_blank"
             >

--- a/src/components/forms/c-disabled/c-disabled.css
+++ b/src/components/forms/c-disabled/c-disabled.css
@@ -21,7 +21,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 .disabled{
     display: inline-block;
-    margin-top: 8px;
+    margin-top: 6px;
     color: var(--c_subOneMain);
     font-style: italic;
     word-break: break-word;

--- a/src/components/forms/c-form-error/c-form-error.html
+++ b/src/components/forms/c-form-error/c-form-error.html
@@ -6,7 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-error.css"></require>
 
-    <span class="${styles.base}  ${styles[state]}">
+    <span
+        class="
+            ${styles.base}
+            ${styles[state]}
+        "
+    >
         <span class="${styles.errorBlock}">
             <slot></slot>
         </span>

--- a/src/components/forms/c-form-image/c-form-image.html
+++ b/src/components/forms/c-form-image/c-form-image.html
@@ -8,7 +8,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <label
         for="${id}"
-        class="${styles.label}  ${styles[state]}"
+        class="
+            ${styles.label}
+            ${styles[state]}
+        "
     >
         <div class="${styles.container}">
             <div class="${styles.image}">

--- a/src/components/forms/c-form-image/c-form-image.html
+++ b/src/components/forms/c-form-image/c-form-image.html
@@ -6,18 +6,28 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-image.css"></require>
 
-    <label for="${id}" class="${styles.label}  ${styles[state]}">
+    <label
+        for="${id}"
+        class="${styles.label}  ${styles[state]}"
+    >
         <div class="${styles.container}">
             <div class="${styles.image}">
                 <div class="${styles.center}">
-                    <img src="${imageUrl}" alt="${id}">
+                    <img
+                        src="${imageUrl}"
+                        alt="${id}"
+                    >
                 </div>
             </div>
             <div class="${styles.input}">
                 <div class="${styles.inputCover}"></div>
                 <l-cluster spacing="var(--s-4)">
                     <div>
-                        <c-radio-input name="${name}" id="${id}" checked.bind="checked"></c-radio-input>
+                        <c-radio-input
+                            name="${name}"
+                            id="${id}"
+                            checked.bind="checked"
+                        ></c-radio-input>
                         <span class="${styles.desc}">${description}</span>
                     </div>
                 </l-cluster>

--- a/src/components/forms/c-form-warning/c-form-warning.html
+++ b/src/components/forms/c-form-warning/c-form-warning.html
@@ -6,7 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-warning.css"></require>
 
-    <span class="${styles.base}  ${styles[state]}">
+    <span
+        class="
+            ${styles.base}
+            ${styles[state]}
+        "
+    >
         <span class="${styles.warningBlock}">
             <slot></slot>
         </span>

--- a/src/components/forms/c-label/c-label.html
+++ b/src/components/forms/c-label/c-label.html
@@ -7,9 +7,25 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-label.css"></require>
 
     <label class="${styles.label}  ${styles[state]}">
-        <c-icon icon="${icon}" color="${labelIconColor}" if.bind="icon"></c-icon>
+        <c-icon
+            icon="${icon}"
+            color="${labelIconColor}"
+            if.bind="icon"
+        ></c-icon>
         <slot></slot>
-        <span class="${styles.edit}" click.trigger="editingActionFunction()" if.bind="editable && notEditing">Edit</span>
-        <span class="${styles.edit}  ${styles.done}" click.trigger="doneEditingActionFunction()" if.bind="editable && editing">Done</span>
+        <span
+            class="${styles.edit}"
+            click.trigger="editingActionFunction()"
+            if.bind="editable && notEditing"
+        >
+            Edit
+        </span>
+        <span
+            class="${styles.edit}  ${styles.done}"
+            click.trigger="doneEditingActionFunction()"
+            if.bind="editable && editing"
+        >
+            Done
+        </span>
     </label>
 </template>

--- a/src/components/forms/c-label/c-label.html
+++ b/src/components/forms/c-label/c-label.html
@@ -6,7 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-label.css"></require>
 
-    <label class="${styles.label}  ${styles[state]}">
+    <label
+        class="
+            ${styles.label}
+            ${styles[state]}
+        "
+    >
         <c-icon
             icon="${icon}"
             color="${labelIconColor}"
@@ -21,7 +26,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             Edit
         </span>
         <span
-            class="${styles.edit}  ${styles.done}"
+            class="
+                ${styles.edit}
+                ${styles.done}
+            "
             click.trigger="doneEditingActionFunction()"
             if.bind="editable && editing"
         >

--- a/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.html
+++ b/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.html
@@ -7,19 +7,34 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-form-checkbox-radio-container.css"></require>
 
     <l-stack spacing="var(--s-4)">
-        <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && _state !== 'disabled' && label">
+        <div
+            class="${styles.labelWrapper}"
+            show.bind="_state !== 'hidden' && _state !== 'disabled' && label"
+        >
             <c-label state="${_state}">
                 ${label}
             </c-label>
             <slot name="tip"></slot>
         </div>
-
-        <div class="${styles[layout]}  ${label === undefined ? styles.noLabel : ''}  js-input-list" show.bind="_state !== 'hidden' && _state !== 'disabled'">
+        <div
+            class="${styles[layout]}  ${label === undefined ? styles.noLabel : ''}  js-input-list"
+            show.bind="_state !== 'hidden' && _state !== 'disabled'"
+        >
             <l-stack spacing="var(--s-4)">
                 <slot></slot>
             </l-stack>
         </div>
-        <c-form-error state="${_state}" if.bind="_state !== 'hidden' && _state !== 'disabled' && errorMsg">${errorMsg}</c-form-error>
-        <c-form-warning state="${_state}" if.bind="_state !== 'hidden' && _state !== 'disabled' && warningMsg">${warningMsg}</c-form-warning>
+        <c-form-error
+            state="${_state}"
+            if.bind="_state !== 'hidden' && _state !== 'disabled' && errorMsg"
+        >
+            ${errorMsg}
+        </c-form-error>
+        <c-form-warning
+            state="${_state}"
+            if.bind="_state !== 'hidden' && _state !== 'disabled' && warningMsg"
+        >
+            ${warningMsg}
+        </c-form-warning>
     </l-stack>
 </template>

--- a/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.html
+++ b/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.html
@@ -17,7 +17,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <slot name="tip"></slot>
         </div>
         <div
-            class="${styles[layout]}  ${label === undefined ? styles.noLabel : ''}  js-input-list"
+            class="
+                ${styles[layout]}
+                ${label === undefined ? styles.noLabel : ''}
+                js-input-list
+            "
             show.bind="_state !== 'hidden' && _state !== 'disabled'"
         >
             <l-stack spacing="var(--s-4)">

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.html
@@ -6,5 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-checkbox-input.css"></require>
 
-    <input disabled.bind="state === 'disabled'" id="${id}" type="checkbox" class="${styles.check}  ${state === 'disabled' ? styles.disabled : ''}" checked.bind="checkedValue" change.delegate="valueChanged()">
+    <input
+        disabled.bind="state === 'disabled'"
+        id="${id}"
+        type="checkbox"
+        class="${styles.check}  ${state === 'disabled' ? styles.disabled : ''}"
+        checked.bind="checkedValue"
+        change.delegate="valueChanged()"
+    >
 </template>

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.html
@@ -10,7 +10,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         disabled.bind="state === 'disabled'"
         id="${id}"
         type="checkbox"
-        class="${styles.check}  ${state === 'disabled' ? styles.disabled : ''}"
+        class="
+            ${styles.check}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
         checked.bind="checkedValue"
         change.delegate="valueChanged()"
     >

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.html
@@ -6,5 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-checkbox-label.css"></require>
 
-    <label class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}" for="${id}"><slot></slot></label>
+    <label
+        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        for="${id}"
+    >
+        <slot></slot>
+    </label>
 </template>

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.html
@@ -7,7 +7,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-checkbox-label.css"></require>
 
     <label
-        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        class="
+            ${styles.label}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
         for="${id}"
     >
         <slot></slot>

--- a/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.css
+++ b/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.css
@@ -22,6 +22,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .draggable{
     height: 15px;
     width: 11px;
+    margin-bottom: 0 !important;
     vertical-align: top;
 }
 

--- a/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
@@ -17,8 +17,18 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     class="${styles.draggable}"
                     drag-options.bind="dragOptions"
                 ></c-drag-handle>
-                <c-checkbox-input id="${id}" checked-value.bind="checkedValue" state="${_state}" on-change.call="valueChanged(val)"></c-checkbox-input>
-                <c-checkbox-label id="${id}" state="${_state}"><slot></slot></c-checkbox-label>
+                <c-checkbox-input
+                    id="${id}"
+                    checked-value.bind="checkedValue"
+                    state="${_state}"
+                    on-change.call="valueChanged(val)"
+                ></c-checkbox-input>
+                <c-checkbox-label
+                    id="${id}"
+                    state="${_state}"
+                >
+                    <slot></slot>
+                </c-checkbox-label>
             </div>
         </l-cluster>
     </div>

--- a/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
+++ b/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
@@ -7,8 +7,19 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     <div show.bind="_state !== 'hidden'">
         <l-cluster spacing="var(--s-5)">
             <div>
-                <c-radio-input name="${name}" id="${id}" checked.bind="checked" state="${_state}"></c-radio-input>
-                <c-radio-label name="${name}" id="${id}" state="${_state}"><slot></slot></c-radio-label>
+                <c-radio-input
+                    name="${name}"
+                    id="${id}"
+                    checked.bind="checked"
+                    state="${_state}"
+                ></c-radio-input>
+                <c-radio-label
+                    name="${name}"
+                    id="${id}"
+                    state="${_state}"
+                >
+                    <slot></slot>
+                </c-radio-label>
             </div>
         </l-cluster>
     </div>

--- a/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.html
+++ b/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.html
@@ -12,7 +12,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         id="${id}"
         name="${name}"
         type="radio"
-        class="${styles.radio}  ${state === 'disabled' ? styles.disabled : ''}  js-radio"
+        class="
+            ${styles.radio}
+            ${state === 'disabled' ? styles.disabled : ''}
+            js-radio
+        "
         checked.bind="checked"
         model="${id}"
     >

--- a/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.html
+++ b/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.html
@@ -6,5 +6,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-radio-input.css"></require>
 
-    <input disabled.bind="state === 'disabled'" id.bind="id" id="${id}" name="${name}" type="radio" class="${styles.radio}  ${state === 'disabled' ? styles.disabled : ''}  js-radio" checked.bind="checked" model="${id}">
+    <input
+        disabled.bind="state === 'disabled'"
+        id.bind="id"
+        id="${id}"
+        name="${name}"
+        type="radio"
+        class="${styles.radio}  ${state === 'disabled' ? styles.disabled : ''}  js-radio"
+        checked.bind="checked"
+        model="${id}"
+    >
 </template>

--- a/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.html
+++ b/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.html
@@ -6,5 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-radio-label.css"></require>
 
-    <label class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}" for="${id}"><slot></slot></label>
+    <label
+        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        for="${id}"
+    >
+        <slot></slot>
+    </label>
 </template>

--- a/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.html
+++ b/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.html
@@ -7,7 +7,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-radio-label.css"></require>
 
     <label
-        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        class="
+            ${styles.label}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
         for="${id}"
     >
         <slot></slot>

--- a/src/components/forms/checkbox-radio/toggle/c-form-toggle/c-form-toggle.html
+++ b/src/components/forms/checkbox-radio/toggle/c-form-toggle/c-form-toggle.html
@@ -5,8 +5,22 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 <template>
 	<require from="./c-form-toggle.css"></require>
-    <div show.bind="_state !== 'hidden'" class="${styles.base}">
-        <c-toggle-input id="${id}" checked-value.bind="checkedValue" state="${_state}" on-change.call="valueChanged(val)"></c-toggle-input>
-        <c-toggle-label id="${id}" state="${_state}"><slot></slot></c-toggle-label>
+
+    <div
+        show.bind="_state !== 'hidden'"
+        class="${styles.base}"
+    >
+        <c-toggle-input
+            id="${id}"
+            checked-value.bind="checkedValue"
+            state="${_state}"
+            on-change.call="valueChanged(val)"
+        ></c-toggle-input>
+        <c-toggle-label
+            id="${id}"
+            state="${_state}"
+        >
+            <slot></slot>
+        </c-toggle-label>
     </div>
 </template>

--- a/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.html
+++ b/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.html
@@ -6,7 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-toggle-input.css"></require>
 
-    <label class="${styles.bin} ${state === 'disabled' ? styles.disabled : ''}">
+    <label
+        class="
+            ${styles.bin}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
+    >
         <input
             disabled.bind="state === 'disabled'"
             id="${id}"

--- a/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.html
+++ b/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.html
@@ -5,8 +5,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 <template>
 	<require from="./c-toggle-input.css"></require>
+
     <label class="${styles.bin} ${state === 'disabled' ? styles.disabled : ''}">
-        <input disabled.bind="state === 'disabled'" id="${id}" type="checkbox" class="${styles.check}" checked.bind="checkedValue" change.delegate="valueChanged()">
+        <input
+            disabled.bind="state === 'disabled'"
+            id="${id}"
+            type="checkbox"
+            class="${styles.check}"
+            checked.bind="checkedValue"
+            change.delegate="valueChanged()"
+        >
         <div class="${styles.bar}"></div>
         <div class="${styles.nub}"></div>
     </label>

--- a/src/components/forms/checkbox-radio/toggle/c-toggle-label/c-toggle-label.html
+++ b/src/components/forms/checkbox-radio/toggle/c-toggle-label/c-toggle-label.html
@@ -6,5 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-toggle-label.css"></require>
 
-    <label class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}" for="${id}"><slot></slot></label>
+    <label
+        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        for="${id}"
+    >
+        <slot></slot>
+    </label>
 </template>

--- a/src/components/forms/checkbox-radio/toggle/c-toggle-label/c-toggle-label.html
+++ b/src/components/forms/checkbox-radio/toggle/c-toggle-label/c-toggle-label.html
@@ -7,7 +7,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-toggle-label.css"></require>
 
     <label
-        class="${styles.label}  ${state === 'disabled' ? styles.disabled : ''}"
+        class="
+            ${styles.label}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
         for="${id}"
     >
         <slot></slot>

--- a/src/components/forms/date/c-form-date/c-form-date.html
+++ b/src/components/forms/date/c-form-date/c-form-date.html
@@ -6,8 +6,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-date.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
-        <c-label state="${_state}" icon="${labelIcon}" if.bind="label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="_state !== 'hidden' && label"
+    >
+        <c-label
+            state="${_state}"
+            icon="${labelIcon}"
+            if.bind="label"
+        >
             ${label}
         </c-label>
         <slot name="tip"></slot>
@@ -29,6 +36,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <span if.bind="disabledText">${disabledText}</span>
         </c-disabled>
     </div>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
-    <c-form-warning state="${_state}" if.bind="_state !== 'hidden' && warningMsg">${warningMsg}</c-form-warning>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
+    <c-form-warning
+        state="${_state}"
+        if.bind="_state !== 'hidden' && warningMsg"
+    >
+        ${warningMsg}
+    </c-form-warning>
 </template>

--- a/src/components/forms/date/c-form-date/c-form-date.html
+++ b/src/components/forms/date/c-form-date/c-form-date.html
@@ -19,7 +19,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         </c-label>
         <slot name="tip"></slot>
     </div>
-    <div class="${styles.container}  ${inline ? styles.inlineContainer : ''}">
+    <div
+        class="
+            ${styles.container}
+            ${inline ? styles.inlineContainer : ''}
+        "
+    >
         <c-text-input
             if.bind="_state !== 'disabled' && _state !== 'hidden'"
             placeholder.bind="placeholder"

--- a/src/components/forms/file/c-file-input/c-file-input.html
+++ b/src/components/forms/file/c-file-input/c-file-input.html
@@ -6,11 +6,24 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-file-input.css"></require>
 
-    <div class="${styles.image}" if.bind="imagePicker">
+    <div
+        class="${styles.image}"
+        if.bind="imagePicker"
+    >
         <span>
             <a href="#">Upload</a>
         </span>
-        <input type="file" class="${styles.file}  ${state === 'error' ? styles.error : ''}" change.delegate="filesUploaded($event)" accept="image/*">
+        <input
+            type="file"
+            class="${styles.file}  ${state === 'error' ? styles.error : ''}"
+            change.delegate="filesUploaded($event)"
+            accept="image/*"
+        >
     </div>
-    <input type="file" class="${styles.file}  ${state === 'error' ? styles.error : ''}" if.bind="!imagePicker" change.delegate="filesUploaded($event)">
+    <input
+        type="file"
+        class="${styles.file}  ${state === 'error' ? styles.error : ''}"
+        if.bind="!imagePicker"
+        change.delegate="filesUploaded($event)"
+    >
 </template>

--- a/src/components/forms/file/c-file-input/c-file-input.html
+++ b/src/components/forms/file/c-file-input/c-file-input.html
@@ -14,15 +14,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <a href="#">Upload</a>
         </span>
         <input
+            class="
+                ${styles.file}
+                ${state === 'error' ? styles.error : ''}
+            "
             type="file"
-            class="${styles.file}  ${state === 'error' ? styles.error : ''}"
             change.delegate="filesUploaded($event)"
             accept="image/*"
         >
     </div>
     <input
+        class="
+            ${styles.file}
+            ${state === 'error' ? styles.error : ''}
+        "
         type="file"
-        class="${styles.file}  ${state === 'error' ? styles.error : ''}"
         if.bind="!imagePicker"
         change.delegate="filesUploaded($event)"
     >

--- a/src/components/forms/file/c-form-file/c-form-file.css
+++ b/src/components/forms/file/c-form-file/c-form-file.css
@@ -75,7 +75,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     text-align: center;
 }
 
-.is-uploading > div{
+.is-uploading > c-spinner{
     position: absolute;
     top: 0;
     left: 0;

--- a/src/components/forms/file/c-form-file/c-form-file.html
+++ b/src/components/forms/file/c-form-file/c-form-file.html
@@ -25,7 +25,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <c-p>No Image</c-p>
     </div>
     <div
-        class="${styles.imageSrcContainer}  ${isUploading ? styles.isUploading : ''}"
+        class="
+            ${styles.imageSrcContainer}
+            ${isUploading ? styles.isUploading : ''}
+        "
         if.bind="imgUrl && imagePicker"
     >
         <c-spinner
@@ -54,15 +57,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <span if.bind="!files.length">None</span>
     </c-disabled>
     <a
-        click.delegate="removeImage()"
         class="${styles.removeImage}"
+        click.delegate="removeImage()"
         if.bind="imagePicker && imgUrl !== imageSrc && !showReset && _state !== 'disabled'"
     >
         Reset
     </a>
     <a
-        click.delegate="resetImage()"
         class="${styles.removeImage}"
+        click.delegate="resetImage()"
         if.bind="imagePicker && showReset && _state !== 'disabled'"
     >
         Reset

--- a/src/components/forms/file/c-form-file/c-form-file.html
+++ b/src/components/forms/file/c-form-file/c-form-file.html
@@ -6,25 +6,71 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-file.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
-        <c-label state="${_state}" if.bind="label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="_state !== 'hidden' && label"
+    >
+        <c-label
+            state="${_state}"
+            if.bind="label"
+        >
             ${label}
         </c-label>
         <slot name="tip"></slot>
     </div>
-    <div class="${styles.noImage}" if.bind="!imgUrl && imagePicker">
+    <div
+        class="${styles.noImage}"
+        if.bind="!imgUrl && imagePicker"
+    >
         <c-p>No Image</c-p>
     </div>
-    <div if.bind="imgUrl && imagePicker" class="${styles.imageSrcContainer}  ${isUploading ? styles.isUploading : ''}">
-        <c-spinner size="small" if.bind="isUploading"></c-spinner>
-        <img class="${styles.image}" src="${imgUrl}" alt="${label}">
+    <div
+        class="${styles.imageSrcContainer}  ${isUploading ? styles.isUploading : ''}"
+        if.bind="imgUrl && imagePicker"
+    >
+        <c-spinner
+            size="small"
+            if.bind="isUploading"
+        ></c-spinner>
+        <img
+            class="${styles.image}"
+            src="${imgUrl}"
+            alt="${label}"
+        >
     </div>
-    <c-file-input image-picker.bind="imagePicker" if.bind="_state !== 'disabled' && _state !== 'hidden'" state.bind="_state" files.bind="files"></c-file-input>
+    <c-file-input
+        image-picker.bind="imagePicker"
+        state.bind="_state"
+        files.bind="files"
+        if.bind="_state !== 'disabled' && _state !== 'hidden'"
+    ></c-file-input>
     <c-disabled if.bind="_state === 'disabled' && !imagePicker">
-        <span if.bind="files.length" repeat.for="f of files">${f.name}</span>
+        <span
+            if.bind="files.length"
+            repeat.for="f of files"
+        >
+            ${f.name}
+        </span>
         <span if.bind="!files.length">None</span>
     </c-disabled>
-    <a if.bind="imagePicker && imgUrl !== imageSrc && !showReset && _state !== 'disabled'" click.delegate="removeImage()" class="${styles.removeImage}">Reset</a>
-    <a if.bind="imagePicker && showReset && _state !== 'disabled'" click.delegate="resetImage()" class="${styles.removeImage}">Reset</a>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
+    <a
+        click.delegate="removeImage()"
+        class="${styles.removeImage}"
+        if.bind="imagePicker && imgUrl !== imageSrc && !showReset && _state !== 'disabled'"
+    >
+        Reset
+    </a>
+    <a
+        click.delegate="resetImage()"
+        class="${styles.removeImage}"
+        if.bind="imagePicker && showReset && _state !== 'disabled'"
+    >
+        Reset
+    </a>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
 </template>

--- a/src/components/forms/select/c-form-add-remove/c-form-add-remove.css
+++ b/src/components/forms/select/c-form-add-remove/c-form-add-remove.css
@@ -22,7 +22,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .container{
     display: flex;
     justify-content: space-between;
-    height: 100%;
 }
 
 .container c-form-select{
@@ -31,8 +30,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     flex: 1;
 }
 
-.container c-form-select > div:nth-child(2){
+.container c-form-select > l-stack{
     height: 100%;
+}
+
+.container l-stack > div{
+    height: unset;
 }
 
 .container select,
@@ -40,8 +43,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     flex: 1;
 }
 
-.container > div{
-    justify-content: center;
+.container > l-stack{
     flex: 0;
     margin: 20px var(--s-2) 0;
+}
+
+.container > l-stack > div{
+    justify-content: center;
 }

--- a/src/components/forms/select/c-form-add-remove/c-form-add-remove.css
+++ b/src/components/forms/select/c-form-add-remove/c-form-add-remove.css
@@ -22,6 +22,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .container{
     display: flex;
     justify-content: space-between;
+    height: 100%;
 }
 
 .container c-form-select{

--- a/src/components/forms/select/c-form-add-remove/c-form-add-remove.html
+++ b/src/components/forms/select/c-form-add-remove/c-form-add-remove.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-add-remove.css"></require>
 
-    <div class="${styles.container}" hide.bind="_state === 'hidden'">
+    <div
+        class="${styles.container}"
+        hide.bind="_state === 'hidden'"
+    >
         <c-form-select
             options.two-way="listLeft"
             label="${titleLeft}"
@@ -20,8 +23,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             scroll-to-load.bind="scrollToLoadLeft"
             actions.bind="actionsLeft"
         >
-            <span slot="tip" show.bind="tipLeftContent">
-                <c-tip side="bottom" icon-tip.bind="true" arrow-position="leftEdge" size="medium">
+            <span
+                slot="tip"
+                show.bind="tipLeftContent"
+            >
+                <c-tip
+                    side="bottom"
+                    icon-tip.bind="true"
+                    arrow-position="leftEdge"
+                    size="medium"
+                >
                     <div slot="trigger">
                         <c-icon icon="question"></c-icon>
                     </div>
@@ -63,8 +74,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             scroll-to-load.bind="scrollToLoadRight"
             actions.bind="actionsRight"
         >
-            <span slot="tip" show.bind="tipRightContent">
-                <c-tip side="bottom" icon-tip.bind="true" arrow-position="rightEdge" size="medium">
+            <span
+                slot="tip"
+                show.bind="tipRightContent"
+            >
+                <c-tip
+                    side="bottom"
+                    icon-tip.bind="true"
+                    arrow-position="rightEdge"
+                    size="medium"
+                >
                     <div slot="trigger">
                         <c-icon icon="question"></c-icon>
                     </div>

--- a/src/components/forms/select/c-form-select/c-form-select.css
+++ b/src/components/forms/select/c-form-select/c-form-select.css
@@ -40,6 +40,7 @@ c-form-select{
     -moz-appearance: none;
     display: block;
     width: 100%;
+    height: unset;
     padding: var(--s-5) var(--s-3);
     border: solid 1px var(--c_black);
     border-radius: 0;
@@ -157,7 +158,7 @@ select.error{
 
 .loader{
     position: absolute;
-    top: 60px;
+    top: 25px;
     bottom: 0;
     width: 100%;
     min-height: 109px;

--- a/src/components/forms/select/c-form-select/c-form-select.html
+++ b/src/components/forms/select/c-form-select/c-form-select.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
     <require from="./c-form-select.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="_state !== 'hidden' && label"
+    >
         <c-label state="${_state}">
             ${label}
         </c-label>
@@ -32,25 +35,64 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             multiple.bind="multiple"
             scroll.trigger="onScroll() & throttle"
         >
-            <option if.bind="!simple" repeat.for="option of filteredOptions" value="${option.value}">${option.text}</option>
-            <option if.bind="simple" repeat.for="option of filteredOptions" value="${option}">${option}</option>
+            <option
+                repeat.for="option of filteredOptions"
+                value="${option.value}"
+                if.bind="!simple"
+            >
+                ${option.text}
+            </option>
+            <option
+                repeat.for="option of filteredOptions"
+                value="${option}"
+                if.bind="simple"
+            >
+                ${option}
+            </option>
         </select>
         <l-cluster
             spacing="var(--s-3)"
             if.bind="reorder"
         >
             <div>
-                <c-button size="small" color="neutral" icon="chevron-up" icon-position="center" click.trigger="moveItems(-1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
-                <c-button size="small" color="neutral" icon="chevron-down" icon-position="center" click.trigger="moveItems(1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
+                <c-button
+                    size="small"
+                    color="neutral"
+                    icon="chevron-up"
+                    icon-position="center"
+                    click.trigger="moveItems(-1)"
+                    state="${selectValue.length ? '': 'disabled'}"
+                ></c-button>
+                <c-button
+                    size="small"
+                    color="neutral"
+                    icon="chevron-down"
+                    icon-position="center"
+                    click.trigger="moveItems(1)"
+                    state="${selectValue.length ? '': 'disabled'}"
+                ></c-button>
             </div>
         </l-cluster>
     </l-stack>
-    <div class="${isLoading ? styles.loader : ''}  ${isLoadingMore ? styles.loadingMore : ''}" if.bind="(isLoading || isLoadingMore) && multiple">
+    <div
+        class="${isLoading ? styles.loader : ''}  ${isLoadingMore ? styles.loadingMore : ''}"
+        if.bind="(isLoading || isLoadingMore) && multiple"
+    >
         <c-spinner size="small"></c-spinner>
     </div>
     <c-disabled if.bind="_state === 'disabled'">
         ${selectValue || 'None'}
     </c-disabled>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
-    <c-form-warning state="${_state}" if.bind="_state !== 'hidden' && warningMsg">${warningMsg}</c-form-warning>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
+    <c-form-warning
+        state="${_state}"
+        if.bind="_state !== 'hidden' && warningMsg"
+    >
+        ${warningMsg}
+    </c-form-warning>
 </template>

--- a/src/components/forms/select/c-form-select/c-form-select.html
+++ b/src/components/forms/select/c-form-select/c-form-select.html
@@ -12,9 +12,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         </c-label>
         <slot name="tip"></slot>
     </div>
-    <l-stack spacing="var(--s-3)">
+    <l-stack
+        spacing="var(--s-3)"
+        if.bind="_state !== 'disabled'"
+    >
         <c-form-text
-            if.bind="search && _state !== 'hidden' && _state !== 'disabled'"
+            if.bind="search && _state !== 'hidden'"
             text-value.bind="searchText"
             class="${styles.search}"
             clearable.bind="true"
@@ -23,7 +26,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             button-action.call="searchSelect(textValue)">
         </c-form-text>
         <select
-            if.bind="!isLoading && _state !== 'hidden' && _state !== 'disabled'"
+            if.bind="!isLoading && _state !== 'hidden'"
             class="${styles.select}  ${styles[_state]}  ${multiple ? styles.multiple : ''}"
             value.bind="selectValue"
             multiple.bind="multiple"
@@ -32,14 +35,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <option if.bind="!simple" repeat.for="option of filteredOptions" value="${option.value}">${option.text}</option>
             <option if.bind="simple" repeat.for="option of filteredOptions" value="${option}">${option}</option>
         </select>
-        <div if.bind="reorder">
-            <l-cluster spacing="var(--s-3)">
-                <div>
-                    <c-button size="small" color="neutral" icon="chevron-up" icon-position="center" click.trigger="moveItems(-1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
-                    <c-button size="small" color="neutral" icon="chevron-down" icon-position="center" click.trigger="moveItems(1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
-                </div>
-            </l-cluster>
-        </div>
+        <l-cluster
+            spacing="var(--s-3)"
+            if.bind="reorder"
+        >
+            <div>
+                <c-button size="small" color="neutral" icon="chevron-up" icon-position="center" click.trigger="moveItems(-1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
+                <c-button size="small" color="neutral" icon="chevron-down" icon-position="center" click.trigger="moveItems(1)" state="${selectValue.length ? '': 'disabled'}"></c-button>
+            </div>
+        </l-cluster>
     </l-stack>
     <div class="${isLoading ? styles.loader : ''}  ${isLoadingMore ? styles.loadingMore : ''}" if.bind="(isLoading || isLoadingMore) && multiple">
         <c-spinner size="small"></c-spinner>

--- a/src/components/forms/select/c-form-select/c-form-select.html
+++ b/src/components/forms/select/c-form-select/c-form-select.html
@@ -29,11 +29,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             button-action.call="searchSelect(textValue)">
         </c-form-text>
         <select
-            if.bind="!isLoading && _state !== 'hidden'"
-            class="${styles.select}  ${styles[_state]}  ${multiple ? styles.multiple : ''}"
+            class="
+                ${styles.select}
+                ${styles[_state]}
+                ${multiple ? styles.multiple : ''}
+            "
             value.bind="selectValue"
             multiple.bind="multiple"
             scroll.trigger="onScroll() & throttle"
+            if.bind="!isLoading && _state !== 'hidden'"
         >
             <option
                 repeat.for="option of filteredOptions"
@@ -75,7 +79,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         </l-cluster>
     </l-stack>
     <div
-        class="${isLoading ? styles.loader : ''}  ${isLoadingMore ? styles.loadingMore : ''}"
+        class="
+            ${isLoading ? styles.loader : ''}
+            ${isLoadingMore ? styles.loadingMore : ''}
+        "
         if.bind="(isLoading || isLoadingMore) && multiple"
     >
         <c-spinner size="small"></c-spinner>

--- a/src/components/forms/slider/c-form-slider/c-form-slider.html
+++ b/src/components/forms/slider/c-form-slider/c-form-slider.html
@@ -7,8 +7,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-form-slider.css"></require>
 
     <div class="${inline ? styles.inline : ''}">
-        <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
-            <c-label state="${_state}" if.bind="label">
+        <div
+            class="${styles.labelWrapper}"
+            show.bind="_state !== 'hidden' && label"
+        >
+            <c-label
+                state="${_state}"
+                if.bind="label"
+            >
                 ${label}
             </c-label>
             <slot name="tip"></slot>
@@ -21,5 +27,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             debounce-time.bind="debounceTime"
         ></c-slider>
     </div>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
 </template>

--- a/src/components/forms/slider/c-slider/c-slider.html
+++ b/src/components/forms/slider/c-slider/c-slider.html
@@ -7,7 +7,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-slider.css"></require>
 
     <input
-        class="${styles.slider}  ${state === 'disabled' ? styles.disabled : ''}"
+        class="
+            ${styles.slider}
+            ${state === 'disabled' ? styles.disabled : ''}
+        "
         type="range"
         step="1"
         max="${increments}"

--- a/src/components/forms/text/c-form-text/c-form-text.html
+++ b/src/components/forms/text/c-form-text/c-form-text.html
@@ -6,8 +6,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
     <require from="./c-form-text.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
-        <c-label state="${_state}" icon="${labelIcon}" label-icon-color="${labelIconColor}">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="_state !== 'hidden' && label"
+    >
+        <c-label
+            state="${_state}"
+            icon="${labelIcon}"
+            label-icon-color="${labelIconColor}"
+        >
             ${label}
         </c-label>
         <slot name="tip"></slot>
@@ -33,6 +40,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     <c-disabled if.bind="_state === 'disabled'">
         ${textValue || 'None'}
     </c-disabled>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
-    <c-form-warning state="${_state}" if.bind="_state !== 'hidden' && warningMsg">${warningMsg}</c-form-warning>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
+    <c-form-warning
+        state="${_state}"
+        if.bind="_state !== 'hidden' && warningMsg"
+    >
+        ${warningMsg}
+    </c-form-warning>
 </template>

--- a/src/components/forms/text/c-form-text/c-form-text.html
+++ b/src/components/forms/text/c-form-text/c-form-text.html
@@ -20,7 +20,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <slot name="tip"></slot>
     </div>
     <c-text-input
-        if.bind="_state !== 'disabled' && _state !== 'hidden'"
+        class="
+            ${icon ? styles.icon : ''}
+            ${styles[iconPosition]}
+            ${alignInput && !label ? styles.alignInput : ''}
+        "
         has-focus.bind="hasFocus"
         placeholder.bind="placeholder"
         icon.bind="icon"
@@ -32,9 +36,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         button-action.call="onButtonAction(textValue)"
         clearable.bind="clearable"
         state.bind="_state"
-        class="${icon ? styles.icon : ''}  ${styles[iconPosition]}  ${alignInput && !label ? styles.alignInput : ''}"
         text-value.bind="textValue"
         event-listeners.bind="eventListeners"
+        if.bind="_state !== 'disabled' && _state !== 'hidden'"
     >
     </c-text-input>
     <c-disabled if.bind="_state === 'disabled'">

--- a/src/components/forms/text/c-text-input/c-text-input.html
+++ b/src/components/forms/text/c-text-input/c-text-input.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-text-input.css"></require>
 
-    <c-icon if.bind="icon" icon="${icon}"></c-icon>
+    <c-icon
+        if.bind="icon"
+        icon="${icon}"
+    ></c-icon>
     <span class="${button || buttonText ? styles.buttonInput : ''} ${clearable ? styles.container : ''}">
         <input
             if.bind="placeholder"
@@ -29,7 +32,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             id="${id}"
             autocomplete="off"
         >
-        <a class="${styles.clearable} ${button ? styles.clearButton : ''}" click.delegate="clearText()" if.bind="clearable && textValue">
+        <a
+            class="${styles.clearable} ${button ? styles.clearButton : ''}"
+            click.delegate="clearText()"
+            if.bind="clearable && textValue"
+        >
             <c-icon icon="x"></c-icon>
         </a>
         <c-button

--- a/src/components/forms/text/c-text-input/c-text-input.html
+++ b/src/components/forms/text/c-text-input/c-text-input.html
@@ -10,42 +10,63 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         if.bind="icon"
         icon="${icon}"
     ></c-icon>
-    <span class="${button || buttonText ? styles.buttonInput : ''} ${clearable ? styles.container : ''}">
+    <span
+        class="
+            ${button || buttonText ? styles.buttonInput : ''}
+            ${clearable ? styles.container : ''}
+        "
+    >
         <input
-            if.bind="placeholder"
+            class="
+                ${styles.input}
+                ${styles[iconPosition]}
+                ${state === 'error' ? styles.error : ''}
+                ${state === 'warning' ? styles.warning : ''}
+            "
             keyup.delegate="onKeyUp($event) & debounce"
             type="${type}"
-            class="${styles.input}  ${styles[iconPosition]}  ${state === 'error' ? styles.error : ''}  ${state === 'warning' ? styles.warning : ''}"
             placeholder.bind="placeholder"
             value.bind="textValue"
             focus.bind="hasFocus"
             id="${id}"
             autocomplete="off"
+            if.bind="placeholder"
         >
         <input
-            if.bind="!placeholder"
+            class="
+                ${styles.input}
+                ${styles[iconPosition]}
+                ${state === 'error' ? styles.error : ''}
+                ${state === 'warning' ? styles.warning : ''}
+            "
             keyup.delegate="onKeyUp($event) & debounce"
             type="${type}"
-            class="${styles.input}  ${styles[iconPosition]}  ${state === 'error' ? styles.error : ''}  ${state === 'warning' ? styles.warning : ''}"
             value.bind="textValue"
             focus.bind="hasFocus"
             id="${id}"
             autocomplete="off"
+            if.bind="!placeholder"
         >
         <a
-            class="${styles.clearable} ${button ? styles.clearButton : ''}"
+            class="
+                ${styles.clearable}
+                ${button ? styles.clearButton : ''}
+            "
             click.delegate="clearText()"
             if.bind="clearable && textValue"
         >
             <c-icon icon="x"></c-icon>
         </a>
         <c-button
-            if.bind="button || buttonText"
+            class="
+                ${styles.button}
+                ${button === 'bin' ? styles.bin : ''}
+            "
             color="neutral"
             icon="${button}"
             icon-position="center"
-            class="${styles.button} ${button === 'bin' ? styles.bin : ''}"
             click.delegate="buttonFn()"
+            if.bind="button || buttonText"
         >
             ${buttonText}
         </c-button>

--- a/src/components/forms/textarea/c-form-textarea/c-form-textarea.html
+++ b/src/components/forms/textarea/c-form-textarea/c-form-textarea.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-form-textarea.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="_state !== 'hidden' && label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="_state !== 'hidden' && label"
+    >
         <c-label state="${_state}">
             ${label}
         </c-label>
@@ -22,6 +25,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     <c-disabled if.bind="_state === 'disabled'">
         ${textareaValue || 'None'}
     </c-disabled>
-    <c-form-error state="${_state}" if.bind="_state !== 'hidden' && errorMsg">${errorMsg}</c-form-error>
-    <c-form-warning state="${_state}" if.bind="_state !== 'hidden' && warningMsg">${warningMsg}</c-form-warning>
+    <c-form-error
+        state="${_state}"
+        if.bind="_state !== 'hidden' && errorMsg"
+    >
+        ${errorMsg}
+    </c-form-error>
+    <c-form-warning
+        state="${_state}"
+        if.bind="_state !== 'hidden' && warningMsg"
+    >
+        ${warningMsg}
+    </c-form-warning>
 </template>

--- a/src/components/forms/textarea/c-form-textarea/c-form-textarea.html
+++ b/src/components/forms/textarea/c-form-textarea/c-form-textarea.html
@@ -16,11 +16,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <slot name="tip"></slot>
     </div>
     <c-textarea-input
-        if.bind="_state !== 'disabled' && _state !== 'hidden'"
+        class="
+            ${styles[state]}
+            ${styles.textarea}
+        "
         placeholder.bind="placeholder"
-        class="${styles[state]}  ${styles.textarea}"
         state.bind="_state"
         textarea-value.bind="textareaValue"
+        if.bind="_state !== 'disabled' && _state !== 'hidden'"
     ></c-textarea-input>
     <c-disabled if.bind="_state === 'disabled'">
         ${textareaValue || 'None'}

--- a/src/components/forms/textarea/c-textarea-input/c-textarea-input.html
+++ b/src/components/forms/textarea/c-textarea-input/c-textarea-input.html
@@ -7,7 +7,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-textarea-input.css"></require>
 
     <textarea
-        class="${styles.textarea}  ${state == 'error' ? styles.error : ''}  ${state == 'warning' ? styles.warning : ''}"
+        class="
+            ${styles.textarea}
+            ${state == 'error' ? styles.error : ''}
+            ${state == 'warning' ? styles.warning : ''}
+        "
         placeholder.bind="placeholder"
         value.bind="textareaValue"
     ></textarea>

--- a/src/components/icons/c-icon/c-icon.html
+++ b/src/components/icons/c-icon/c-icon.html
@@ -7,7 +7,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-icon.css"></require>
 
     <svg
-        class="${styles.icon}  ${styles[color]}  ${styles[size]}  ${action ? styles.action : ''}"
+        class="
+            ${styles.icon}
+            ${styles[color]}
+            ${styles[size]}
+            ${action ? styles.action : ''}
+        "
         click.trigger="actionFunction()"
     >
         <use xlink:href="#${icon}"></use>

--- a/src/components/icons/c-icon/c-icon.html
+++ b/src/components/icons/c-icon/c-icon.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-icon.css"></require>
 
-    <svg class="${styles.icon}  ${styles[color]}  ${styles[size]}  ${action ? styles.action : ''}" click.trigger="actionFunction()">
+    <svg
+        class="${styles.icon}  ${styles[color]}  ${styles[size]}  ${action ? styles.action : ''}"
+        click.trigger="actionFunction()"
+    >
         <use xlink:href="#${icon}"></use>
     </svg>
 </template>

--- a/src/components/modal/c-modal/c-modal.html
+++ b/src/components/modal/c-modal/c-modal.html
@@ -6,12 +6,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-modal.css"></require>
 
-    <ux-dialog class="
-        ${styles.dialog}
-        ${styles[model.size]}
-        ${model.size == 'full' ? 'js-full' : ''}
-        ${model.size == 'large' ? 'js-large' : ''}
-    ">
+    <ux-dialog
+        class="
+            ${styles.dialog}
+            ${styles[model.size]}
+            ${model.size == 'full' ? 'js-full' : ''}
+            ${model.size == 'large' ? 'js-large' : ''}
+        "
+    >
         <ux-dialog-header class="${styles.header}">
             <l-cluster
                 spacing="var(--s-1)"
@@ -36,8 +38,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 </div>
             </l-cluster>
             <c-button
-                click.delegate="controller.cancel()"
                 class="${styles.closeButton}"
+                click.delegate="controller.cancel()"
                 icon="x"
                 icon-position="center"
             ></c-button>

--- a/src/components/navs/c-nav-horizontal-item/c-nav-horizontal-item.html
+++ b/src/components/navs/c-nav-horizontal-item/c-nav-horizontal-item.html
@@ -6,23 +6,54 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-nav-horizontal-item.css"></require>
 
-    <li class="${styles.navHorizontalItem}  ${styles[state]}  ${styles[position]}" hide.bind="state === 'hidden'">
-        <a if.bind="route" href.bind="generatedLink" click.trigger="toggleMobileNav()">
+    <li
+        class="${styles.navHorizontalItem}  ${styles[state]}  ${styles[position]}"
+        hide.bind="state === 'hidden'"
+    >
+        <a
+            href.bind="generatedLink"
+            click.trigger="toggleMobileNav()"
+            if.bind="route"
+        >
             ${title}
-            <div class="${styles.icon}" if.bind="icon">
-                <c-icon icon="${icon}" color="${iconColor}"></c-icon>
+            <div
+                class="${styles.icon}"
+                if.bind="icon"
+            >
+                <c-icon
+                    icon="${icon}"
+                    color="${iconColor}"
+                ></c-icon>
             </div>
         </a>
-        <a if.bind="href" href="${href}">
+        <a
+            href="${href}"
+            if.bind="href"
+        >
             ${title}
-            <div class="${styles.icon}" if.bind="icon">
-                <c-icon icon="${icon}" color="${iconColor}"></c-icon>
+            <div
+                class="${styles.icon}"
+                if.bind="icon"
+            >
+                <c-icon
+                    icon="${icon}"
+                    color="${iconColor}"
+                ></c-icon>
             </div>
         </a>
-        <a if.bind="action" click.trigger="actionFunction()">
+        <a
+            click.trigger="actionFunction()"
+            if.bind="action"
+        >
             ${title}
-            <div class="${styles.icon}" if.bind="icon">
-                <c-icon icon="${icon}" color="${iconColor}"></c-icon>
+            <div
+                class="${styles.icon}"
+                if.bind="icon"
+            >
+                <c-icon
+                    icon="${icon}"
+                    color="${iconColor}"
+                ></c-icon>
             </div>
         </a>
         <slot></slot>

--- a/src/components/navs/c-nav-horizontal-item/c-nav-horizontal-item.html
+++ b/src/components/navs/c-nav-horizontal-item/c-nav-horizontal-item.html
@@ -7,7 +7,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-nav-horizontal-item.css"></require>
 
     <li
-        class="${styles.navHorizontalItem}  ${styles[state]}  ${styles[position]}"
+        class="
+            ${styles.navHorizontalItem}
+            ${styles[state]}
+            ${styles[position]}
+        "
         hide.bind="state === 'hidden'"
     >
         <a

--- a/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
+++ b/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
@@ -6,11 +6,22 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-nav-horizontal.css"></require>
 
-    <nav class="${styles.navHorizontal}  ${styles[size]}" hide.bind="state === 'hidden'">
-        <button class="${styles.mobileTrigger}  ${mobileNavOpen.open ? styles.mobileTriggerActive : ''}" if.bind="mobile" click.trigger="toggleMobileNav()">
+    <nav
+        class="${styles.navHorizontal}  ${styles[size]}"
+        hide.bind="state === 'hidden'"
+    >
+        <button
+            class="${styles.mobileTrigger}  ${mobileNavOpen.open ? styles.mobileTriggerActive : ''}"
+            click.trigger="toggleMobileNav()"
+            if.bind="mobile"
+        >
             <span>Mobile Nav</span>
         </button>
-        <l-cluster align="${align}" justify="{$justify}" spacing="${spacing}">
+        <l-cluster
+            align="${align}"
+            justify="{$justify}"
+            spacing="${spacing}"
+        >
             <ul class="${mobile ? styles.navMobile : ''}  ${mobileNavOpen.open ? styles.navMobileActive : ''}">
                 <slot></slot>
             </ul>

--- a/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
+++ b/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
@@ -7,11 +7,17 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-nav-horizontal.css"></require>
 
     <nav
-        class="${styles.navHorizontal}  ${styles[size]}"
+        class="
+            ${styles.navHorizontal}
+            ${styles[size]}
+        "
         hide.bind="state === 'hidden'"
     >
         <button
-            class="${styles.mobileTrigger}  ${mobileNavOpen.open ? styles.mobileTriggerActive : ''}"
+            class="
+                ${styles.mobileTrigger}
+                ${mobileNavOpen.open ? styles.mobileTriggerActive : ''}
+            "
             click.trigger="toggleMobileNav()"
             if.bind="mobile"
         >
@@ -22,7 +28,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             justify="{$justify}"
             spacing="${spacing}"
         >
-            <ul class="${mobile ? styles.navMobile : ''}  ${mobileNavOpen.open ? styles.navMobileActive : ''}">
+            <ul
+                class="
+                    ${mobile ? styles.navMobile : ''}
+                    ${mobileNavOpen.open ? styles.navMobileActive : ''}
+                "
+            >
                 <slot></slot>
             </ul>
         </l-cluster>

--- a/src/components/navs/c-nav-vertical-item/c-nav-vertical-item.html
+++ b/src/components/navs/c-nav-vertical-item/c-nav-vertical-item.html
@@ -18,19 +18,36 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         hide.bind="state === 'hidden'"
         drag-dropzone.bind="dropzoneActions"
     >
-        <span class="${styles.accordionArrow}" if.bind="accordionItem">
+        <span
+            class="${styles.accordionArrow}"
+            if.bind="accordionItem"
+        >
             <svg class="icon">
                 <use xlink:href="#chevron-right"></use>
             </svg>
         </span>
-        <a if.bind="accordionItem && title" click.trigger="toggleAccordion()" class="${styles.accordionLink}">
+        <a
+            click.trigger="toggleAccordion()"
+            class="${styles.accordionLink}"
+            if.bind="accordionItem && title"
+        >
             ${title}
         </a>
-        <a if.bind="!accordionItem && title" click.delegate="clickTrigger()">
+        <a
+            if.bind="!accordionItem && title"
+            click.delegate="clickTrigger()"
+        >
             ${title}
-            <span class="${styles.sub}" if.bind="subText">${subText}</span>
+            <span
+                class="${styles.sub}"
+                if.bind="subText"
+            >${subText}</span>
         </a>
-        <div if.bind="icon && iconAction" click.trigger="actionFunction()" class="${styles.iconContainer}">
+        <div
+            click.trigger="actionFunction()"
+            class="${styles.iconContainer}"
+            if.bind="icon && iconAction"
+        >
             <c-icon icon="${icon}"></c-icon>
         </div>
         <h4 if.bind="sectionTitle">${sectionTitle}</h4>

--- a/src/components/navs/c-nav-vertical-sliding/c-nav-vertical-sliding.html
+++ b/src/components/navs/c-nav-vertical-sliding/c-nav-vertical-sliding.html
@@ -6,20 +6,46 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-nav-vertical-sliding.css"></require>
 
-    <div class="${styles.container} ${navState === 'right' ? styles[navState] : ''}  ${!showHidden ? styles.hidden : ''}" show.bind="!isPageLoading">
-        <div class="${styles.block}" repeat.for="page of nav.pages">
+    <div
+        class="${styles.container} ${navState === 'right' ? styles[navState] : ''}  ${!showHidden ? styles.hidden : ''}"
+        show.bind="!isPageLoading"
+    >
+        <div
+            class="${styles.block}"
+            repeat.for="page of nav.pages"
+        >
             <div class="${styles.triggerContainer}  ${(isTriggerContentHidden && $index === 0) ? styles.triggerContentHidden : ''}">
                 <div>
-                    <div class="${styles.trigger}" click.trigger="toggleNav()" show.bind="page.prevText && (showTrigger || $index > 0)">
-                        <c-icon icon="chevron-left" size="itzy"></c-icon>
+                    <div
+                        class="${styles.trigger}"
+                        click.trigger="toggleNav()"
+                        show.bind="page.prevText && (showTrigger || $index > 0)"
+                    >
+                        <c-icon
+                            icon="chevron-left"
+                            size="itzy"
+                        ></c-icon>
                         <span>${page.prevText}</span>
                     </div>
-                    <div class="${styles.trigger}" click.trigger="toggleNav()" show.bind="page.nextText && (showTrigger || $index > 0)">
+                    <div
+                        class="${styles.trigger}"
+                        click.trigger="toggleNav()"
+                        show.bind="page.nextText && (showTrigger || $index > 0)"
+                    >
                         <span>${page.nextText}</span>
-                        <c-icon icon="chevron-right" size="itzy"></c-icon>
+                        <c-icon
+                            icon="chevron-right"
+                            size="itzy"
+                        ></c-icon>
                     </div>
                 </div>
-                <c-h3 truncate.bind="true" dark-back.bind="true" if.bind="page.title && (showTrigger || $index > 0)">${page.title}</c-h3>
+                <c-h3
+                    truncate.bind="true"
+                    dark-back.bind="true"
+                    if.bind="page.title && (showTrigger || $index > 0)"
+                >
+                    ${page.title}
+                </c-h3>
                 <c-form-text
                     placeholder.bind="page.searchPlaceholder"
                     button="search"
@@ -27,8 +53,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     text-value.bind="page.searchQuery"
                     button-action.call="page.searchFn(textValue)"
                     if.bind="page.searchFn && page.searchPlaceholder && (showTrigger || $index > 0)"
-                >
-                </c-form-text>
+                ></c-form-text>
                 <c-notification if.bind="!page.navs.length">No Results Found</c-notification>
             </div>
             <c-nav-vertical
@@ -69,5 +94,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             </c-nav-vertical>
         </div>
     </div>
-    <c-spinner size="small" if.bind="isPageLoading"></c-spinner>
+    <c-spinner
+        size="small"
+        if.bind="isPageLoading"
+    ></c-spinner>
 </template>

--- a/src/components/navs/c-nav-vertical-sliding/c-nav-vertical-sliding.html
+++ b/src/components/navs/c-nav-vertical-sliding/c-nav-vertical-sliding.html
@@ -7,14 +7,23 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-nav-vertical-sliding.css"></require>
 
     <div
-        class="${styles.container} ${navState === 'right' ? styles[navState] : ''}  ${!showHidden ? styles.hidden : ''}"
+        class="
+            ${styles.container}
+            ${navState === 'right' ? styles[navState] : ''}
+            ${!showHidden ? styles.hidden : ''}
+        "
         show.bind="!isPageLoading"
     >
         <div
             class="${styles.block}"
             repeat.for="page of nav.pages"
         >
-            <div class="${styles.triggerContainer}  ${(isTriggerContentHidden && $index === 0) ? styles.triggerContentHidden : ''}">
+            <div
+                class="
+                    ${styles.triggerContainer}
+                    ${(isTriggerContentHidden && $index === 0) ? styles.triggerContentHidden : ''}
+                "
+            >
                 <div>
                     <div
                         class="${styles.trigger}"

--- a/src/components/navs/c-nav-vertical/c-nav-vertical.html
+++ b/src/components/navs/c-nav-vertical/c-nav-vertical.html
@@ -6,7 +6,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-nav-vertical.css"></require>
 
-    <nav class="${styles.navVertical}  ${navBottom ? styles.navBottom : ''}">
+    <nav
+        class="
+            ${styles.navVertical}
+            ${navBottom ? styles.navBottom : ''}"
+        >
         <ul
             class="${navBottom ? styles.overflow : ''}"
             scroll.trigger="onScroll($event) & throttle"

--- a/src/components/navs/c-nav-vertical/c-nav-vertical.html
+++ b/src/components/navs/c-nav-vertical/c-nav-vertical.html
@@ -7,10 +7,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-nav-vertical.css"></require>
 
     <nav class="${styles.navVertical}  ${navBottom ? styles.navBottom : ''}">
-        <ul class="${navBottom ? styles.overflow : ''}" scroll.trigger="onScroll($event) & throttle">
+        <ul
+            class="${navBottom ? styles.overflow : ''}"
+            scroll.trigger="onScroll($event) & throttle"
+        >
         	<slot></slot>
         </ul>
-        <ul class="${styles.secondList}" show.bind="navBottom">
+        <ul
+            class="${styles.secondList}"
+            show.bind="navBottom"
+        >
         	<slot name="bottom"></slot>
         </ul>
     </nav>

--- a/src/components/notifications/c-notification/c-notification.html
+++ b/src/components/notifications/c-notification/c-notification.html
@@ -7,10 +7,20 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-notification.css"></require>
 
     <div
-        class="${styles.notification}  ${styles[type]}"
+        class="
+            ${styles.notification}
+            ${styles[type]}
+        "
         show.bind="_state !== 'hidden'"
     >
-        <c-icon icon="${type == 'info' ? 'info' : ''}${type == 'success' ? 'info' : ''}${type == 'warning' ? 'warning' : ''}${type == 'critical' ? 'warning' : ''}"></c-icon>
+        <c-icon
+            icon="
+                ${type == 'info' ? 'info' : ''}
+                ${type == 'success' ? 'info' : ''}
+                ${type == 'warning' ? 'warning' : ''}
+                ${type == 'critical' ? 'warning' : ''}
+            "
+        ></c-icon>
         <div
             class="${styles.callout}"
             if.bind="calloutTitle || calloutContent"

--- a/src/components/notifications/c-notification/c-notification.html
+++ b/src/components/notifications/c-notification/c-notification.html
@@ -6,9 +6,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-notification.css"></require>
 
-    <div class="${styles.notification}  ${styles[type]}" show.bind="_state !== 'hidden'">
+    <div
+        class="${styles.notification}  ${styles[type]}"
+        show.bind="_state !== 'hidden'"
+    >
         <c-icon icon="${type == 'info' ? 'info' : ''}${type == 'success' ? 'info' : ''}${type == 'warning' ? 'warning' : ''}${type == 'critical' ? 'warning' : ''}"></c-icon>
-        <div class="${styles.callout}" if.bind="calloutTitle || calloutContent">
+        <div
+            class="${styles.callout}"
+            if.bind="calloutTitle || calloutContent"
+        >
             <c-h5>${calloutTitle}</c-h5>
             <c-h2>${calloutContent}</c-h2>
         </div>

--- a/src/components/notifications/c-notification/c-notification.html
+++ b/src/components/notifications/c-notification/c-notification.html
@@ -13,14 +13,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         "
         show.bind="_state !== 'hidden'"
     >
-        <c-icon
-            icon="
-                ${type == 'info' ? 'info' : ''}
-                ${type == 'success' ? 'info' : ''}
-                ${type == 'warning' ? 'warning' : ''}
-                ${type == 'critical' ? 'warning' : ''}
-            "
-        ></c-icon>
+        <c-icon icon="${type == 'info' ? 'info' : ''}${type == 'success' ? 'info' : ''}${type == 'warning' ? 'warning' : ''}${type == 'critical' ? 'warning' : ''}"></c-icon>
         <div
             class="${styles.callout}"
             if.bind="calloutTitle || calloutContent"

--- a/src/components/pills/c-pill/c-pill.html
+++ b/src/components/pills/c-pill/c-pill.html
@@ -8,7 +8,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <span
         show.bind="!href"
-        class="${styles.pill}  ${styles[color]}"
+        class="
+            ${styles.pill}
+            ${styles[color]}
+        "
     >
         <c-icon
             icon="${icon}"
@@ -21,7 +24,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     </span>
     <a
         href.bind="href"
-        class="${styles.pill}  ${styles[color]}"
+        class="
+            ${styles.pill}
+            ${styles[color]}
+        "
         show.bind="href"
     >
         <c-icon

--- a/src/components/pills/c-pill/c-pill.html
+++ b/src/components/pills/c-pill/c-pill.html
@@ -6,12 +6,31 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-pill.css"></require>
 
-    <span show.bind="!href" class="${styles.pill}  ${styles[color]}">
-        <c-icon icon="${icon}" color="white" size="itzy" action.call="actionFunction()" if.bind="icon"></c-icon>
+    <span
+        show.bind="!href"
+        class="${styles.pill}  ${styles[color]}"
+    >
+        <c-icon
+            icon="${icon}"
+            color="white"
+            size="itzy"
+            action.call="actionFunction()"
+            if.bind="icon"
+        ></c-icon>
         <slot name="pill-content"></slot>
     </span>
-    <a show.bind="href" href.bind="href" class="${styles.pill}  ${styles[color]}">
-        <c-icon icon="${icon}" color="white" size="itzy" action.call="actionFunction()" if.bind="icon"></c-icon>
+    <a
+        href.bind="href"
+        class="${styles.pill}  ${styles[color]}"
+        show.bind="href"
+    >
+        <c-icon
+            icon="${icon}"
+            color="white"
+            size="itzy"
+            action.call="actionFunction()"
+            if.bind="icon"
+        ></c-icon>
 		<slot name="pill-link-content"></slot>
 	</a>
 </template>

--- a/src/components/popover/c-popover/c-popover.html
+++ b/src/components/popover/c-popover/c-popover.html
@@ -10,7 +10,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         class="${styles.overlay}"
         if.bind="vPopoverService.model"
     >
-        <div class="${styles.closeTrigger}" click.trigger="vPopoverService.close()"></div>
+        <div
+            class="${styles.closeTrigger}"
+            click.trigger="vPopoverService.close()"
+        ></div>
         <div
             class="
                 ${styles.popover}
@@ -26,12 +29,24 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     margin-top: ${vPopoverService.model.top ? vPopoverService.model.top + 'px' : ''};
                 "
             >
-                <div class="${tipStyles.tip}  ${styles.container}" id="popover-container">
+                <div
+                    class="${tipStyles.tip}  ${styles.container}"
+                    id="popover-container"
+                >
                     <div class="${styles.containerInner}">
-                        <compose if.bind="vPopoverService.model.contentViewModel && vPopoverService.model.data" view-model.bind="vPopoverService.model.contentViewModel" model.bind="{data: vPopoverService.model.data}"></compose>
+                        <compose
+                            view-model.bind="vPopoverService.model.contentViewModel"
+                            model.bind="{data: vPopoverService.model.data}"
+                            if.bind="vPopoverService.model.contentViewModel && vPopoverService.model.data"
+                        ></compose>
                         <p else>Empty</p>
                     </div>
-                    <span class="${tipStyles.close}  ${styles.close}" click.trigger="vPopoverService.close()">×</span>
+                    <span
+                        class="${tipStyles.close}  ${styles.close}"
+                        click.trigger="vPopoverService.close()"
+                    >
+                        ×
+                    </span>
                     <span
                         class="${tipStyles.color}"
                         css="--tip-bar-color: ${vPopoverService.color};"

--- a/src/components/popover/c-popover/c-popover.html
+++ b/src/components/popover/c-popover/c-popover.html
@@ -30,7 +30,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 "
             >
                 <div
-                    class="${tipStyles.tip}  ${styles.container}"
+                    class="
+                        ${tipStyles.tip}
+                        ${styles.container}
+                    "
                     id="popover-container"
                 >
                     <div class="${styles.containerInner}">

--- a/src/components/tables/c-table-fixed-header/c-table-fixed-header.html
+++ b/src/components/tables/c-table-fixed-header/c-table-fixed-header.html
@@ -6,11 +6,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-table-fixed-header.css"></require>
 
-    <div class="${styles.fixedTableHeaderBg}" css="${(totalWidth > windowWidth) ? 'width:' + totalWidth + 'px' : ''}"></div>
-    <div class="${styles.fixedTableHeader}" css="${(totalWidth > windowWidth) ? 'width:' + totalWidth + 'px' : ''}" scroll.trigger="onScroll() & throttle">
+    <div
+        class="${styles.fixedTableHeaderBg}"
+        css="${(totalWidth > windowWidth) ? 'width:' + totalWidth + 'px' : ''}"
+    ></div>
+    <div
+        class="${styles.fixedTableHeader}"
+        css="${(totalWidth > windowWidth) ? 'width:' + totalWidth + 'px' : ''}"
+        scroll.trigger="onScroll() & throttle"
+    >
         <slot></slot>
     </div>
-    <div if.bind="isLoading" class="${styles.loader}">
+    <div
+        class="${styles.loader}"
+        if.bind="isLoading"
+    >
         <c-spinner size="small"></c-spinner>
     </div>
 </template>

--- a/src/components/tables/c-table/c-table.html
+++ b/src/components/tables/c-table/c-table.html
@@ -8,7 +8,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <table
         if.bind="_state !== 'hidden'"
-        class="${styles.table}  ${striped ? styles.striped : ''}  ${hover ? styles.hover : ''}  ${noVerticalBorders ? styles.noVerticalBorders : ''}  ${responsive ? styles.responsive : ''}"
+        class="
+            ${styles.table}
+            ${striped ? styles.striped : ''}
+            ${hover ? styles.hover : ''}
+            ${noVerticalBorders ? styles.noVerticalBorders : ''}
+            ${responsive ? styles.responsive : ''}
+        "
     >
         <colgroup>
             <col
@@ -65,5 +71,4 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             </tr>
         </tbody>
     </table>
-
 </template>

--- a/src/components/tables/c-td/c-td.html
+++ b/src/components/tables/c-td/c-td.html
@@ -6,7 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-td.css"></require>
 
-    <compose if.bind="col.view" view.bind="col.view" view-model.bind="col.viewModel" model.bind="modelData"></compose>
+    <compose
+        view.bind="col.view"
+        view-model.bind="col.viewModel"
+        model.bind="modelData"
+        if.bind="col.view"
+    ></compose>
     <span if.bind="!col.view">
         ${modelData.value | meta:col.valueConverter:col.valueConverterFormat}
     </span>

--- a/src/components/tables/td-contents/c-td-action/c-td-action.html
+++ b/src/components/tables/td-contents/c-td-action/c-td-action.html
@@ -6,11 +6,25 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-td-action.css"></require>
 
-    <span class="${styles.base}" if.bind="row[col.colHeadName + 'Icon'] && col.colAction" click.delegate="col.colAction(row)">
+    <span
+        class="${styles.base}"
+        if.bind="row[col.colHeadName + 'Icon'] && col.colAction"
+        click.delegate="col.colAction(row)"
+    >
         <c-icon icon="${row[col.colHeadName + 'Icon']}"></c-icon>
     </span>
-
-    <a class="${styles.base}" if.bind="row[col.colHeadName + 'URL']" href="${row[col.colHeadName + 'URL']}">${value}</a>
-
-    <span class="${styles.base}  ${styles.textAction}" if.bind="col.colAction" click.delegate="col.colAction(row)">${value}</span>
+    <a
+        class="${styles.base}"
+        href="${row[col.colHeadName + 'URL']}"
+        if.bind="row[col.colHeadName + 'URL']"
+    >
+        ${value}
+    </a>
+    <span
+        class="${styles.base}  ${styles.textAction}"
+        click.delegate="col.colAction(row)"
+        if.bind="col.colAction"
+    >
+        ${value}
+    </span>
 </template>

--- a/src/components/tables/td-contents/c-td-action/c-td-action.html
+++ b/src/components/tables/td-contents/c-td-action/c-td-action.html
@@ -21,7 +21,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         ${value}
     </a>
     <span
-        class="${styles.base}  ${styles.textAction}"
+        class="
+            ${styles.base}
+            ${styles.textAction}
+        "
         click.delegate="col.colAction(row)"
         if.bind="col.colAction"
     >

--- a/src/components/tables/td-contents/c-td-button/c-td-button.html
+++ b/src/components/tables/td-contents/c-td-button/c-td-button.html
@@ -5,12 +5,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 <template>
     <c-button
-            size="small"
-            color="${row[col.colHeadName + 'ButtonColor'] ? row[col.colHeadName + 'ButtonColor'] : 'primary'}"
-            state="${row[col.colHeadName + 'ButtonState']}"
-            icon="${row[col.colHeadName + 'ButtonIcon']}"
-            icon-position="center"
-            action.call="col.colAction(row)">
+        size="small"
+        color="${row[col.colHeadName + 'ButtonColor'] ? row[col.colHeadName + 'ButtonColor'] : 'primary'}"
+        state="${row[col.colHeadName + 'ButtonState']}"
+        icon="${row[col.colHeadName + 'ButtonIcon']}"
+        icon-position="center"
+        action.call="col.colAction(row)"
+    >
         ${value}
     </c-button>
 </template>

--- a/src/components/tables/td-contents/c-td-drag-check/c-td-drag-check.html
+++ b/src/components/tables/td-contents/c-td-drag-check/c-td-drag-check.html
@@ -4,9 +4,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 -->
 
 <template>
-    <c-drag-handle
-        drag-options.bind="col.getDragOptions(row)"
-    >
-    </c-drag-handle>
+    <c-drag-handle drag-options.bind="col.getDragOptions(row)"></c-drag-handle>
     <c-checkbox-input checked-value.bind="row[col.colHeadName]"></c-checkbox-input>
 </template>

--- a/src/components/tables/td-contents/c-td-image/c-td-image.html
+++ b/src/components/tables/td-contents/c-td-image/c-td-image.html
@@ -6,5 +6,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-td-image.css"></require>
 
-    <img class="${styles.image}" src="${value}" alt="${row[col.colHeadName + 'Alt']}">
+    <img
+        class="${styles.image}"
+        src="${value}"
+        alt="${row[col.colHeadName + 'Alt']}"
+    >
 </template>

--- a/src/components/tables/td-contents/c-td-text-input/c-td-text-input.html
+++ b/src/components/tables/td-contents/c-td-text-input/c-td-text-input.html
@@ -4,5 +4,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 -->
 
 <template>
-    <c-form-text acl-restricted text-value.bind="row[col.colHeadName]" keyup.delegate="changeDetection(row, col)"></c-form-text>
+    <c-form-text
+        acl-restricted
+        text-value.bind="row[col.colHeadName]"
+        keyup.delegate="changeDetection(row, col)"
+    ></c-form-text>
 </template>

--- a/src/components/tables/td-contents/c-td-tip/c-td-tip.html
+++ b/src/components/tables/td-contents/c-td-tip/c-td-tip.html
@@ -4,7 +4,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 -->
 
 <template>
-    <c-tip side="${row[col.colHeadName + 'TipSide']}" arrow-position="${row[col.colHeadName + 'TipArrowPosition']}" size="${row[col.colHeadName + 'TipSize']}" icon-tip.bind="true">
+    <c-tip
+        side="${row[col.colHeadName + 'TipSide']}"
+        arrow-position="${row[col.colHeadName + 'TipArrowPosition']}"
+        size="${row[col.colHeadName + 'TipSize']}"
+        icon-tip.bind="true"
+    >
         <div slot="trigger">
             <span if.bind="row[col.colHeadName + 'TipTriggerIcon']">
                 <c-icon icon="${row[col.colHeadName + 'TipTriggerIcon']}"></c-icon>
@@ -12,7 +17,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <span if.bind="row[col.colHeadName + 'TipTriggerText']">${row[col.colHeadName + 'TipTriggerText']}</span>
         </div>
         <div slot="content">
-            <compose if.bind="row[col.colHeadName + 'TipViewModel']" view-model.bind="row[col.colHeadName + 'TipViewModel']" model.bind="{row:row, col:col}"></compose>
+            <compose
+                if.bind="row[col.colHeadName + 'TipViewModel']"
+                view-model.bind="row[col.colHeadName + 'TipViewModel']"
+                model.bind="{row:row, col:col}"
+            ></compose>
         </div>
     </c-tip>
 </template>

--- a/src/components/tables/td-contents/c-td-truncate/c-td-truncate.html
+++ b/src/components/tables/td-contents/c-td-truncate/c-td-truncate.html
@@ -7,12 +7,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-td-truncate.css"></require>
 
 	<c-tip
-	if.bind="row[col.colHeadName + 'Tip']"
-	side="${row[col.colHeadName + 'TipSide']}"
-	arrow-position="${row[col.colHeadName + 'TipArrowPosition']}"
-	size="${row[col.colHeadName + 'TipSize']}"
-	fill-width-trigger.bind="true"
-	force-close.bind="true">
+        if.bind="row[col.colHeadName + 'Tip']"
+        side="${row[col.colHeadName + 'TipSide']}"
+        arrow-position="${row[col.colHeadName + 'TipArrowPosition']}"
+        size="${row[col.colHeadName + 'TipSize']}"
+        fill-width-trigger.bind="true"
+        force-close.bind="true"
+    >
 		<div slot="trigger" >
 			<div class="${styles.container}">
 				<div class="${styles.truncate}">
@@ -22,17 +23,27 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 			</div>
 		</div>
 		<div slot="content">
-			<compose if.bind="row[col.colHeadName + 'TipViewModel']" view-model.bind="row[col.colHeadName + 'TipViewModel']" model.bind="{row:row, col:col}"></compose>
+			<compose
+                if.bind="row[col.colHeadName + 'TipViewModel']"
+                view-model.bind="row[col.colHeadName + 'TipViewModel']"
+                model.bind="{row:row, col:col}"
+            ></compose>
 			<div else>${value}</div>
 		</div>
 	</c-tip>
 
     <div else class="${styles.container}">
-        <c-icon icon="${row[col.colHeadName + 'Icon']}" if.bind="row[col.colHeadName + 'Icon']"></c-icon>
+        <c-icon
+            icon="${row[col.colHeadName + 'Icon']}"
+            if.bind="row[col.colHeadName + 'Icon']"
+        ></c-icon>
         <div class="${styles.truncate}">
             <span title="${value}">
                 <span if.bind="!searchHighlight">${value}</span>
-                <span if.bind="searchHighlight" innerhtml.bind="searchHighlight"></span>
+                <span
+                    if.bind="searchHighlight"
+                    innerhtml.bind="searchHighlight"
+                ></span>
             </span>
         </div>
     </div>

--- a/src/components/tile/c-tile/c-tile.html
+++ b/src/components/tile/c-tile/c-tile.html
@@ -6,42 +6,93 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-tile.css"></require>
 
-    <div class="${styles.tile}  ${checkedValue ? styles.checked : ''}  ${hover ? styles.hover : ''}" id="${id}" if.bind="_state !== 'hidden'">
-        <div title="${title}" class="${styles.container}">
-            <c-tip side="left" size="small" icon-tip.bind="true" class="${styles.tip}" if.bind="showTip">
+    <div
+        class="${styles.tile}  ${checkedValue ? styles.checked : ''}  ${hover ? styles.hover : ''}"
+        id="${id}"
+        if.bind="_state !== 'hidden'"
+    >
+        <div
+            title="${title}"
+            class="${styles.container}"
+        >
+            <c-tip
+                side="left"
+                size="small"
+                icon-tip.bind="true"
+                class="${styles.tip}"
+                if.bind="showTip"
+            >
                 <div slot="trigger">
-                    <c-icon icon="${tipIcon}" color="lightGray"></c-icon>
+                    <c-icon
+                        icon="${tipIcon}"
+                        color="lightGray"
+                    ></c-icon>
                 </div>
                 <div slot="content">
                     <template part="tip-content" replaceable></template>
                 </div>
             </c-tip>
-            <div class="${styles.image}" css="height: ${imageContainerHeight}px;" click.trigger="tileClick()">
+            <div
+                class="${styles.image}"
+                css="height: ${imageContainerHeight}px;"
+                click.trigger="tileClick()"
+            >
                 <c-drag-handle
                     class="${styles.drag}"
                     if.bind="showDrag"
                     drag-draggable.bind="dragOptions"
+                ></c-drag-handle>
+                <div
+                    class="${styles.status}  ${styles[status]}"
+                    if.bind="status"
+                ></div>
+                <img
+                    if.bind="imageUrl"
+                    src="${imageUrl}"
+                    alt="Image Loading"
+                    title="${id}"
                 >
-                </c-drag-handle>
-                <div class="${styles.status}  ${styles[status]}" if.bind="status"></div>
-                <img if.bind="imageUrl" src="${imageUrl}" alt="Image Loading" title="${id}">
-                <c-h5 color="smoke" if.bind="!imageUrl">${noImageMessage}</c-h5>
+                <c-h5
+                    color="smoke"
+                    if.bind="!imageUrl"
+                >
+                    ${noImageMessage}
+                </c-h5>
             </div>
             <div class="${styles.title}">
                 <l-cluster spacing="var(--s-4)">
                     <div>
-                        <div class="${styles.checkboxContainer}" if.bind="showCheckbox && _state !== 'disabled'">
+                        <div
+                            class="${styles.checkboxContainer}"
+                            if.bind="showCheckbox && _state !== 'disabled'"
+                        >
                             <c-checkbox-input checked-value.bind="checkedValue"></c-checkbox-input>
                         </div>
-                        <c-h4 spacing-bottom="sbNone" truncate.bind="true" click.trigger="showCheckbox && state !== 'disabled' ? checkedValue = !checkedValue : ''">
-                            <c-icon icon="${titleIcon}" size="tiny" if.bind="titleIcon"></c-icon>
+                        <c-h4
+                            truncate.bind="true"
+                            click.trigger="showCheckbox && state !== 'disabled' ? checkedValue = !checkedValue : ''"
+                        >
+                            <c-icon
+                                icon="${titleIcon}"
+                                size="tiny"
+                                if.bind="titleIcon"
+                            ></c-icon>
                             <span if.bind="!searchHighlight">${title}</span>
-                            <span if.bind="searchHighlight" innerhtml.bind="searchHighlight"></span>
+                            <span
+                                if.bind="searchHighlight"
+                                innerhtml.bind="searchHighlight"
+                            ></span>
                         </c-h4>
                     </div>
                 </l-cluster>
             </div>
-            <c-p size="small" truncate.bind="true" spacing-bottom="sbNone" click.trigger="tileClick()" if.bind="message">${message}</c-p>
+            <c-p
+                size="small"
+                truncate.bind="true"
+                spacing-bottom="sbNone"
+                click.trigger="tileClick()"
+                if.bind="message"
+            >${message}</c-p>
         </div>
     </div>
 </template>

--- a/src/components/tile/c-tile/c-tile.html
+++ b/src/components/tile/c-tile/c-tile.html
@@ -92,7 +92,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 spacing-bottom="sbNone"
                 click.trigger="tileClick()"
                 if.bind="message"
-            >${message}</c-p>
+            >
+                ${message}
+            </c-p>
         </div>
     </div>
 </template>

--- a/src/components/tile/c-tile/c-tile.html
+++ b/src/components/tile/c-tile/c-tile.html
@@ -7,7 +7,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-tile.css"></require>
 
     <div
-        class="${styles.tile}  ${checkedValue ? styles.checked : ''}  ${hover ? styles.hover : ''}"
+        class="
+            ${styles.tile}
+            ${checkedValue ? styles.checked : ''}
+            ${hover ? styles.hover : ''}
+        "
         id="${id}"
         if.bind="_state !== 'hidden'"
     >

--- a/src/components/timeline/c-time-entry/c-time-entry-popover.html
+++ b/src/components/timeline/c-time-entry/c-time-entry-popover.html
@@ -8,11 +8,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
     <div>
         <div class="${styles.container}">
-            <div class="${styles.info}" style="padding: 0;">
-                <c-p truncate.bind="true" size="small" spacing-bottom="sbNone">
+            <div
+                class="${styles.info}"
+                style="padding: 0;"
+            >
+                <c-p
+                    truncate.bind="true"
+                    size="small"
+                >
                     ${item.title}
                 </c-p>
-                <c-p truncate.bind="true" size="small" spacing-bottom="sbNone" if.bind="item.startTime && item.endTime">
+                <c-p
+                    truncate.bind="true"
+                    size="small"
+                    if.bind="item.startTime && item.endTime"
+                >
                     ${item.startTime} - ${item.endTime}
                 </c-p>
             </div>

--- a/src/components/timeline/c-time-entry/c-time-entry.html
+++ b/src/components/timeline/c-time-entry/c-time-entry.html
@@ -30,16 +30,41 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             --time-entry-color: ${item.color ? item.color : 'inherit'};
         "
     >
-        <div click.trigger="openPopover($event)" class="${styles.container}">
+        <div
+            click.trigger="openPopover($event)"
+            class="${styles.container}"
+        >
             <div class="${styles.info}  ${item.icons ? styles.infoWithIcons : ''}">
-                <c-p truncate.bind="true" size="small">
+                <c-p
+                    truncate.bind="true"
+                    size="small"
+                >
                     ${item.title}
                 </c-p>
-                <c-p truncate.bind="true" size="small" if.bind="item.startTime && item.endTime && !item.altTime">${item.startTime} - ${item.endTime}</c-p>
-                <c-p truncate.bind="true" size="small" if.bind="item.altTime">${item.altTime}</c-p>
+                <c-p
+                    truncate.bind="true"
+                    size="small"
+                    if.bind="item.startTime && item.endTime && !item.altTime"
+                >
+                    ${item.startTime} - ${item.endTime}
+                </c-p>
+                <c-p
+                    truncate.bind="true"
+                    size="small"
+                    if.bind="item.altTime"
+                >
+                    ${item.altTime}
+                </c-p>
             </div>
-            <div class="${styles.icons} ${item.shiftIcons ? styles.iconsShift : ''}" if.bind="item.icons">
-                <c-icon repeat.for="icon of item.icons" icon="${icon}" if.bind="$index < 2"></c-icon>
+            <div
+                class="${styles.icons} ${item.shiftIcons ? styles.iconsShift : ''}"
+                if.bind="item.icons"
+            >
+                <c-icon
+                    repeat.for="icon of item.icons"
+                    icon="${icon}"
+                    if.bind="$index < 2"
+                ></c-icon>
             </div>
         </div>
     </div>

--- a/src/components/timeline/c-timeline-block/c-timeline-block.html
+++ b/src/components/timeline/c-timeline-block/c-timeline-block.html
@@ -6,10 +6,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-timeline-block.css"></require>
 
-    <div class="${styles.timeBlock}" click.trigger="togglePopoverFunction($event)">
-        <span if.bind="time" class="${styles.time}">${time}</span>
+    <div
+        class="${styles.timeBlock}"
+        click.trigger="togglePopoverFunction($event)"
+    >
+        <span
+            class="${styles.time}"
+            if.bind="time"
+        >
+            ${time}
+        </span>
         <slot></slot>
-
-        <c-time-entry if.bind="newItem" item.bind="newItem" view-model.ref="placeholderEntry"></c-time-entry>
+        <c-time-entry
+            item.bind="newItem"
+            view-model.ref="placeholderEntry"
+            if.bind="newItem"
+        ></c-time-entry>
     </div>
 </template>

--- a/src/components/timeline/c-timeline-container/c-timeline-container.html
+++ b/src/components/timeline/c-timeline-container/c-timeline-container.html
@@ -18,7 +18,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-spinner if.bind="loading"></c-spinner>
             <div class="${styles.wrapper}">
                 <div
-                    class="${styles.spinner}  ${loadingBottom ? styles.spinnerLoadingBottom : ''}"
+                    class="
+                        ${styles.spinner}
+                        ${loadingBottom ? styles.spinnerLoadingBottom : ''}
+                    "
                     if.bind="loadingTop || loadingBottom"
                 >
                     <c-spinner size="small"></c-spinner>

--- a/src/components/timeline/c-timeline-week-container/c-timeline-week-container.html
+++ b/src/components/timeline/c-timeline-week-container/c-timeline-week-container.html
@@ -9,7 +9,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     <div class="${styles.wrapper}">
         <div class="${styles.dates}">
             <span repeat.for="day of days">
-                <a click.trigger="changeDate(day.date)" class="${day.today ? styles.today : ''}">${day.date | isoToDayWeek}</a>
+                <a
+                    click.trigger="changeDate(day.date)"
+                    class="${day.today ? styles.today : ''}"
+                >
+                    ${day.date | isoToDayWeek}
+                </a>
             </span>
         </div>
         <div class="${styles.days}">

--- a/src/components/timeline/c-timeline/c-timeline.html
+++ b/src/components/timeline/c-timeline/c-timeline.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
     <c-spinner if.bind="isLoading"></c-spinner>
     <c-spinner if.bind="isRendering && !isLoading"></c-spinner>
-    <div if.bind="!isLoading" id.bind="id">
+    <div
+        id.bind="id"
+        if.bind="!isLoading"
+    >
         <div show.bind="!isRendering">
             <c-timeline-container
                 if.bind="timeView === 'day'"
@@ -21,30 +24,37 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     add-entry-offset.call="calculatePlaceholder(isoTime, mouseOffset)"
                     prevent-create.call="checkPreventAdd(isoTime)"
                     new-entry-view-model.bind="newEntryViewModel"
-                >
-                </c-timeline-block>
+                ></c-timeline-block>
                 <c-time-entry
                     repeat.for="entry of transformedEntries"
                     item.bind="entry"
                     class="timeline-day"
-                >
-                </c-time-entry>
+                ></c-time-entry>
             </c-timeline-container>
-            <c-timeline-week-container if.bind="timeView === 'week' || timeView === 'three-day'" days.bind="displayDays" day-click.call="dayClick(date)">
+            <c-timeline-week-container
+                days.bind="displayDays"
+                day-click.call="dayClick(date)"
+                if.bind="timeView === 'week' || timeView === 'three-day'"
+            >
                 <div slot="hours">
                     <c-timeline-container>
-                        <c-timeline-block repeat.for="block of blocks" time.one-time="block.time">
+                        <c-timeline-block
+                            repeat.for="block of blocks"
+                            time.one-time="block.time"
+                        >
                     </c-timeline-container>
                 </div>
-                <c-timeline-container repeat.for="day of displayDays" current-time-top.bind="day.currentTimeLine">
+                <c-timeline-container
+                    repeat.for="day of displayDays"
+                    current-time-top.bind="day.currentTimeLine"
+                >
                     <c-timeline-block
                         repeat.for="block of day.blocks & oneTime"
                         iso-time.bind="block.isoTime"
                         add-entry-offset.call="calculatePlaceholder(isoTime, mouseOffset)"
                         prevent-create.call="checkPreventAdd(isoTime)"
                         new-entry-view-model.bind="newEntryViewModel"
-                    >
-                    </c-timeline-block>
+                    ></c-timeline-block>
                     <c-time-entry
                         repeat.for="entry of day.entries"
                         item.bind="entry"

--- a/src/components/toasts/c-toasts/c-toasts.html
+++ b/src/components/toasts/c-toasts/c-toasts.html
@@ -7,10 +7,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-toasts.css"></require>
 
     <div class="${styles.wrapper}">
-        <div repeat.for="toast of vToastsService.toasts"
-             class="${styles.toaster}  ${styles[toast.type]}"
-             mouseover.trigger="vToastsService.keepAlive(toast.id)"
-             mouseout.trigger="vToastsService.resetTimeout(toast.id)">
+        <div
+            repeat.for="toast of vToastsService.toasts"
+            class="${styles.toaster}  ${styles[toast.type]}"
+            mouseover.trigger="vToastsService.keepAlive(toast.id)"
+            mouseout.trigger="vToastsService.resetTimeout(toast.id)"
+        >
             <div class="${styles.titleBar}">
                 <div class="${styles.iconContainer}">
                     <c-icon
@@ -21,14 +23,25 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     </c-icon>
                 </div>
                 <c-h4 class="${styles.title}">${toast.title}</c-h4>
-                <a href="#" class="${styles.close}" click.trigger="vToastsService.remove(toast)">
-                    <c-icon icon="x" color="lightGray" size="tiny"></c-icon>
+                <a
+                    href="#"
+                    class="${styles.close}"
+                    click.trigger="vToastsService.remove(toast)"
+                >
+                    <c-icon
+                        icon="x"
+                        color="lightGray"
+                        size="tiny"
+                    ></c-icon>
                 </a>
             </div>
 
             <!-- If there is no extra message this can be false -->
-            <div class="${styles.message}" if.bind="true">
-                <c-p spacing-bottom="sbNone">${toast.message}</c-p>
+            <div
+                class="${styles.message}"
+                if.bind="true"
+            >
+                <c-p>${toast.message}</c-p>
             </div>
         </div>
     </div>

--- a/src/components/type/h3/c-h3.html
+++ b/src/components/type/h3/c-h3.html
@@ -6,7 +6,19 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-h3.css"></require>
 
-    <span class="${truncate ? styles.truncate : ''} ${truncate && darkBack ? styles.darkBack : ''}">
-        <h3 class="${styles.base} ${flushTop ? '' : styles.notFlushTop}"><slot></slot></h3>
+    <span
+        class="
+            ${truncate ? styles.truncate : ''}
+            ${truncate && darkBack ? styles.darkBack : ''}
+        "
+    >
+        <h3
+            class="
+                ${styles.base}
+                ${flushTop ? '' : styles.notFlushTop}
+            "
+        >
+            <slot></slot>
+        </h3>
     </span>
 </template>

--- a/src/components/type/h4/c-h4.html
+++ b/src/components/type/h4/c-h4.html
@@ -6,5 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-h4.css"></require>
 
-    <h4 class="${styles.base}  ${truncate ? styles.truncate : ''}"><slot></slot></h4>
+    <h4
+        class="
+            ${styles.base}
+            ${truncate ? styles.truncate : ''}
+        "
+    >
+        <slot></slot>
+    </h4>
 </template>

--- a/src/components/type/h5/c-h5.html
+++ b/src/components/type/h5/c-h5.html
@@ -6,5 +6,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-h5.css"></require>
 
-    <h5 class="${styles.base}  ${styles[color]}"><slot></slot></h5>
+    <h5
+        class="
+            ${styles.base}
+            ${styles[color]}
+        "
+    >
+        <slot></slot>
+    </h5>
 </template>

--- a/src/components/type/list/c-list-container/c-list-container.html
+++ b/src/components/type/list/c-list-container/c-list-container.html
@@ -6,7 +6,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-list-container.css"></require>
 
-    <ul class="${styles.list}  ${styles[color]}  ${styles[size]}  ${dividers ? styles.dividers : ''}">
+    <ul
+        class="
+            ${styles.list}
+            ${styles[color]}
+            ${styles[size]}
+            ${dividers ? styles.dividers : ''}
+        "
+    >
         <slot></slot>
     </ul>
 </template>

--- a/src/components/type/list/c-list-item/c-list-item.html
+++ b/src/components/type/list/c-list-item/c-list-item.html
@@ -6,7 +6,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-list-item.css"></require>
 
-    <li class="${styles.listItem}  ${styles[state]}  ${wrap ? styles.wrap : ''}">
+    <li
+        class="
+            ${styles.listItem}
+            ${styles[state]}
+            ${wrap ? styles.wrap : ''}
+        "
+    >
         <slot></slot>
     </li>
 </template>

--- a/src/components/type/list/c-list/c-list.html
+++ b/src/components/type/list/c-list/c-list.html
@@ -6,7 +6,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-list.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="label"
+    >
         <c-label state="${state}">
             ${label}
         </c-label>

--- a/src/components/type/list/c-list/c-list.html
+++ b/src/components/type/list/c-list/c-list.html
@@ -15,7 +15,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         </c-label>
         <slot name="tip"></slot>
     </div>
-    <ul class="${styles.base}  ${noBullets ? styles.noBullets : ''}">
+    <ul
+        class="
+            ${styles.base}
+            ${noBullets ? styles.noBullets : ''}
+        "
+    >
         <slot></slot>
     </ul>
 </template>

--- a/src/components/utilities/c-drag-handle/c-drag-handle.html
+++ b/src/components/utilities/c-drag-handle/c-drag-handle.html
@@ -10,6 +10,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         class="${styles.base}"
         drag-draggable.bind="dragOptions"
     >
-        <c-icon icon="draggable" color="gray" size.bind="size"></c-icon>
+        <c-icon
+            icon="draggable"
+            color="gray"
+            size.bind="size"
+        ></c-icon>
     </span>
 </template>

--- a/src/components/utilities/c-label-box/c-label-box.html
+++ b/src/components/utilities/c-label-box/c-label-box.html
@@ -6,8 +6,16 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-label-box.css"></require>
 
-    <div class="${styles.labelWrapper}" show.bind="label">
-        <c-label editing-action.call="editFunction()" done-editing-action.call="doneFunction()" editable.bind="editable && _state !== 'disabled'" if.bind="label">
+    <div
+        class="${styles.labelWrapper}"
+        show.bind="label"
+    >
+        <c-label
+            editing-action.call="editFunction()"
+            done-editing-action.call="doneFunction()"
+            editable.bind="editable && _state !== 'disabled'"
+            if.bind="label"
+        >
             ${label}
         </c-label>
         <slot name="tip"></slot>

--- a/src/components/utilities/c-spinner/c-spinner.html
+++ b/src/components/utilities/c-spinner/c-spinner.html
@@ -7,6 +7,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-spinner.css"></require>
 
     <div class="${styles.container}">
-        <span class="${styles.base}  ${styles[size]}"></span>
+        <span
+            class="
+                ${styles.base}
+                ${styles[size]}
+            "
+        ></span>
     </div>
 </template>

--- a/src/components/utilities/c-status/c-status.html
+++ b/src/components/utilities/c-status/c-status.html
@@ -6,11 +6,41 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-status.css"></require>
 
-    <div class="${styles.container}" css="max-width: ${maxWidth}">
-        <div class="${styles.status}  ${styles[state]}" show.bind="state">
-            <c-icon icon="circle" color="${state === 'healthy' ? 'secondary' : state === 'warning' ? 'subTwo' : state === 'critical' ? 'primaryLight' : state === 'info' ? 'subOne' : ''}"></c-icon>
+    <div
+        class="${styles.container}"
+        css="max-width: ${maxWidth}"
+    >
+        <div
+            class="
+                ${styles.status}
+                ${styles[state]}
+            "
+            show.bind="state"
+        >
+            <c-icon
+                icon="circle"
+                color="
+                    ${state === 'healthy' ? 'secondary' :
+                    state === 'warning' ? 'subTwo' :
+                    state === 'critical' ? 'primaryLight' :
+                    state === 'info' ? 'subOne' : ''}
+                "
+            ></c-icon>
         </div>
-        <c-p spacing-bottom="sbNone" title="${text}" if.bind="!href">${text}</c-p>
-        <a href="${href}" class="${styles.link}" target="${targetNew ? '_blank' : '_self'}" title="${text}" if.bind="href">${text}</a>
+        <c-p
+            title="${text}"
+            if.bind="!href"
+        >
+            ${text}
+        </c-p>
+        <a
+            href="${href}"
+            class="${styles.link}"
+            target="${targetNew ? '_blank' : '_self'}"
+            title="${text}"
+            if.bind="href"
+        >
+            ${text}
+        </a>
     </div>
 </template>

--- a/src/components/utilities/c-status/c-status.html
+++ b/src/components/utilities/c-status/c-status.html
@@ -19,12 +19,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         >
             <c-icon
                 icon="circle"
-                color="
-                    ${state === 'healthy' ? 'secondary' :
-                    state === 'warning' ? 'subTwo' :
-                    state === 'critical' ? 'primaryLight' :
-                    state === 'info' ? 'subOne' : ''}
-                "
+                color="${state === 'healthy' ? 'secondary' : state === 'warning' ? 'subTwo' : state === 'critical' ? 'primaryLight' : state === 'info' ? 'subOne' : ''}"
             ></c-icon>
         </div>
         <c-p

--- a/src/layouts/l-box-link/l-box-link.html
+++ b/src/layouts/l-box-link/l-box-link.html
@@ -12,6 +12,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             ${styles.backgroundHover}
             ${borderTop ? styles.borderTop : ''}
             ${scrolling ? styles.scrolling : ''}
+            ${fillSpace ? styles.fillSpace : ''}
         "
         css="
             --box-margin-ends: ${marginEnds};

--- a/src/layouts/l-box-link/l-box-link.test.ts
+++ b/src/layouts/l-box-link/l-box-link.test.ts
@@ -5,7 +5,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 import {StageComponent} from 'aurelia-testing';
 
-describe('l-box component', () => {
+describe('l-box-link component', () => {
     let component;
 
     describe('Integration', () => {
@@ -13,25 +13,9 @@ describe('l-box component', () => {
             component.dispose();
         });
 
-        it('is scrolling endabled', async done => {
-            component = StageComponent.withResources()
-                .inView('<l-box scrolling.bind="isScrolling"></l-box>')
-                .boundTo({
-                    isScrolling: 1,
-                });
-
-            try {
-                await bootStrapEnvironment(component);
-                expect(component.viewModel.scrolling).toBe(false);
-                done();
-            } catch (e) {
-                done.fail(e);
-            }
-        });
-
         it('is fill-space endabled', async done => {
             component = StageComponent.withResources()
-                .inView('<l-box fill-space.bind="isFillSpace"></l-box>')
+                .inView('<l-box-link fill-space.bind="isFillSpace"></l-box-link>')
                 .boundTo({
                     isFillSpace: 1,
                 });
@@ -47,7 +31,7 @@ describe('l-box component', () => {
 
         describe('CSS Classes', () => {
             it('css class: box', async done => {
-                component = StageComponent.withResources().inView('<l-box></l-box>');
+                component = StageComponent.withResources().inView('<l-box-link></l-box-link>');
 
                 try {
                     await bootStrapEnvironment(component);
@@ -59,7 +43,7 @@ describe('l-box component', () => {
             });
 
             it('css class: scrolling', async done => {
-                component = StageComponent.withResources().inView('<l-box></l-box>');
+                component = StageComponent.withResources().inView('<l-box-link></l-box-link>');
 
                 try {
                     await bootStrapEnvironment(component);

--- a/src/layouts/l-box-link/l-box-link.ts
+++ b/src/layouts/l-box-link/l-box-link.ts
@@ -14,6 +14,8 @@ export class LBoxLink {
     @bindable
     public borderTop;
     @bindable
+    public fillSpace = false;
+    @bindable
     public color = 'var(--c_white)';
     @bindable
     public href = '#';
@@ -33,6 +35,10 @@ export class LBoxLink {
     public attached() {
         if (this.target !== '_self' && this.target !== '_blank') {
             this.target = '_self';
+        }
+
+        if (typeof this.fillSpace !== 'boolean') {
+            this.fillSpace = false;
         }
     }
 }

--- a/src/layouts/l-box-link/l-box-link.ts
+++ b/src/layouts/l-box-link/l-box-link.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from '../l-box/l-box.css.json';
 
-@containerless
 export class LBoxLink {
     @bindable
     public background = 'var(--c_darkGray)';

--- a/src/layouts/l-box-link/l-box-link.ts
+++ b/src/layouts/l-box-link/l-box-link.ts
@@ -4,8 +4,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 */
 
 import {bindable} from 'aurelia-framework';
+import {authState} from '../../decorators/auth-state';
 import * as styles from '../l-box/l-box.css.json';
 
+@authState
 export class LBoxLink {
     @bindable
     public background = 'var(--c_darkGray)';

--- a/src/layouts/l-box/l-box.css
+++ b/src/layouts/l-box/l-box.css
@@ -35,6 +35,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     display: block;
 }
 
+.fill-space{
+    height: 100%;
+}
+
 .border-top{
     border-top: solid 1px var(--box-top-border);
 }

--- a/src/layouts/l-box/l-box.css
+++ b/src/layouts/l-box/l-box.css
@@ -32,6 +32,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     padding-left:  var(--box-padding-sides);
     background: var(--box-background);
     color: var(--box-color);
+    display: block;
 }
 
 .border-top{

--- a/src/layouts/l-box/l-box.html
+++ b/src/layouts/l-box/l-box.html
@@ -11,6 +11,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             ${styles.box}
             ${borderTop ? styles.borderTop : ''}
             ${scrolling ? styles.scrolling : ''}
+            ${fillSpace ? styles.fillSpace : ''}
         "
         css="
             --box-margin-ends: ${marginEnds};

--- a/src/layouts/l-box/l-box.ts
+++ b/src/layouts/l-box/l-box.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-box.css.json';
 
-@containerless
 export class LBox {
     @bindable
     public background = 'var(--c_darkGray)';

--- a/src/layouts/l-box/l-box.ts
+++ b/src/layouts/l-box/l-box.ts
@@ -14,6 +14,8 @@ export class LBox {
     @bindable
     public color = 'var(--c_white)';
     @bindable
+    public fillSpace = false;
+    @bindable
     public marginSides = '0px';
     @bindable
     public marginEnds = '0px';
@@ -29,6 +31,10 @@ export class LBox {
     public attached() {
         if (typeof this.scrolling !== 'boolean') {
             this.scrolling = false;
+        }
+
+        if (typeof this.fillSpace !== 'boolean') {
+            this.fillSpace = false;
         }
     }
 }

--- a/src/layouts/l-center/l-center.ts
+++ b/src/layouts/l-center/l-center.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-center.css.json';
 
-@containerless
 export class LCenter {
     @bindable
     public intrinsic = false;

--- a/src/layouts/l-cluster/l-cluster.ts
+++ b/src/layouts/l-cluster/l-cluster.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-cluster.css.json';
 
-@containerless
 export class LCluster {
     @bindable
     public align = 'center';

--- a/src/layouts/l-cover/l-cover.ts
+++ b/src/layouts/l-cover/l-cover.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-cover.css.json';
 
-@containerless
 export class LCover {
     @bindable
     public center = false;

--- a/src/layouts/l-grid/l-grid.html
+++ b/src/layouts/l-grid/l-grid.html
@@ -21,7 +21,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     >
         <slot></slot>
 
-        <div if.bind="isLoading" class="${styles.loader}">
+        <div
+            class="${styles.loader}"
+            if.bind="isLoading"
+        >
             <c-spinner size="small"></c-spinner>
         </div>
     </div>

--- a/src/layouts/l-grid/l-grid.ts
+++ b/src/layouts/l-grid/l-grid.ts
@@ -3,12 +3,11 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import {generateRandom} from '../../helpers/generate-random';
 import {lazyLoadCheck} from '../../helpers/lazy-load-check';
 import * as styles from './l-grid.css.json';
 
-@containerless
 export class LGrid {
     @bindable
     public actions;

--- a/src/layouts/l-sidebar/l-sidebar.ts
+++ b/src/layouts/l-sidebar/l-sidebar.ts
@@ -3,11 +3,10 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import {generateRandom} from '../../helpers/generate-random';
 import * as styles from './l-sidebar.css.json';
 
-@containerless
 export class LSidebar {
     @bindable
     public contentMin = '65%';

--- a/src/layouts/l-stack/l-stack.ts
+++ b/src/layouts/l-stack/l-stack.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-stack.css.json';
 
-@containerless
 export class LStack {
     @bindable
     public list;

--- a/src/layouts/l-switcher/l-switcher.ts
+++ b/src/layouts/l-switcher/l-switcher.ts
@@ -3,10 +3,9 @@ Copyright 2020, Verizon Media
 Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
 */
 
-import {bindable, containerless} from 'aurelia-framework';
+import {bindable} from 'aurelia-framework';
 import * as styles from './l-switcher.css.json';
 
-@containerless
 export class LSwitcher {
     @bindable
     public doubleWidth;


### PR DESCRIPTION
### Problem
using the `containerless` option on components can cause problems in that the rendered html does not have the original tag of the component. Placing `if.bind` and other computations on that tag is then impossible. The layout components were using `containerless` for some css reasons. 

### Solution
Refactor a few things to remove `containerless` from all layout components.

#### Side Note
All components had their html reformatted to be cleaner. That is why so many lines were added.