### PR TITLE
Form upgrades

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -30,7 +30,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         state="${link.isActive ? 'active' : ''}"
                     >
                     </c-nav-horizontal-item>
-                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.1.0"></c-nav-horizontal-item>
+                    <c-nav-horizontal-item position="right" href="https://github.com/bindable-ui/bindable" title="v1.1.1"></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>
         </l-sidebar>

--- a/dev-app/routes/components/forms/date/properties/index.html
+++ b/dev-app/routes/components/forms/date/properties/index.html
@@ -39,7 +39,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                             <c-form-date
                                 id="test31"
                                 label="Icon"
-                                label-icon="info"
+                                label-icon="warning"
+                                label-icon-color="var(--c_subTwoMain)"
                                 error-msg="Date is required"
                             ></c-form-date>
                         </div>

--- a/dev-app/routes/components/forms/date/properties/index.ts
+++ b/dev-app/routes/components/forms/date/properties/index.ts
@@ -23,7 +23,7 @@ export class DateInputProperties {
         },
         {
             _class: 'monospaced',
-            colClass: 't150',
+            colClass: 't190',
             colHeadName: 'default',
             colHeadValue: 'Default',
         },
@@ -72,6 +72,19 @@ export class DateInputProperties {
             description: 'Set the label text. If left off no label will be placed.',
             name: 'label',
             value: 'string',
+        },
+        {
+            description:
+            'Place an icon in front of the label. See icon component for a list of icons.',
+            name: 'label-icon',
+            value: 'Any icon',
+        },
+        {
+            default: 'var(--c_lightGray)',
+            description:
+            'Set the color of the icon in the label.',
+            name: 'label-icon-color',
+            value: 'CSS Color',
         },
         {
             description: 'Leave off if not needed.',

--- a/dev-app/routes/components/forms/text/properties/index.ts
+++ b/dev-app/routes/components/forms/text/properties/index.ts
@@ -23,7 +23,7 @@ export class TextInputProperties {
         },
         {
             _class: 'monospaced',
-            colClass: 't150',
+            colClass: 't190',
             colHeadName: 'default',
             colHeadValue: 'Default',
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.css
+++ b/src/components/forms/checkbox-radio/c-form-checkbox-radio-container/c-form-checkbox-radio-container.css
@@ -37,11 +37,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     margin-top: var(--s-5);
 }
 
-.inline > div{
+.inline > l-stack > div{
     flex-direction: row;
 }
 
-.inline > div > *{
+.inline > l-stack > div > *{
     margin-top: 0;
     margin-right: var(--s2);
 }

--- a/src/components/forms/date/c-form-date/c-form-date.html
+++ b/src/components/forms/date/c-form-date/c-form-date.html
@@ -13,6 +13,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <c-label
             state="${_state}"
             icon="${labelIcon}"
+            label-icon-color="${labelIconColor}"
             if.bind="label"
         >
             ${label}

--- a/src/components/forms/date/c-form-date/c-form-date.ts
+++ b/src/components/forms/date/c-form-date/c-form-date.ts
@@ -42,6 +42,8 @@ export class CFormDate {
     @bindable
     public labelIcon;
     @bindable
+    public labelIconColor = 'var(--c_lightGray)';
+    @bindable
     public placeholder;
     @bindable
     public startOf: moment.unitOfTime.StartOf = 'minute';


### PR DESCRIPTION
### What's new
c-form-date got a new property: `label-icon-color`
it allows you to set the color of the optional icon next to the label

### What's fixed
c-form-checkbox-radio-container inline layout broke a while back with the layout components removing containerless. This is now fixed.