### PR TITLE
Center cover play nice

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -51,7 +51,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.2.2"
+                        title="v1.2.3"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/dev-app/routes/components/navs/horizontal/horizontal-nav/properties/index.html
+++ b/dev-app/routes/components/navs/horizontal/horizontal-nav/properties/index.html
@@ -52,9 +52,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
         <div>
             <l-stack spacing="var(--s-3)">
-                <c-h3>background-color</c-h3>
+                <c-h3>background-color &amp; text-transform</c-h3>
                 <c-code-sample>
-                    <c-nav-horizontal background-color="var(--c_black)">
+                    <c-nav-horizontal background-color="var(--c_black)" text-transform="uppercase">
                         <c-nav-horizontal-item title="Nav Link 1" href="http://google.com"></c-nav-horizontal-item>
                         <c-nav-horizontal-item title="Nav Link 2" href="http://google.com"></c-nav-horizontal-item>
                     </c-nav-horizontal>

--- a/dev-app/routes/components/navs/horizontal/horizontal-nav/properties/index.ts
+++ b/dev-app/routes/components/navs/horizontal/horizontal-nav/properties/index.ts
@@ -71,5 +71,11 @@ export class HorizontalNav {
             name: 'state',
             value: 'hidden',
         },
+        {
+            default: 'unset',
+            description: 'Set the text transform for the nav.',
+            name: 'text-transform',
+            value: 'capitalize | uppercase | lowercase | inital | inherit | unset',
+        },
     ];
 }

--- a/dev-app/routes/layouts/center/index.html
+++ b/dev-app/routes/layouts/center/index.html
@@ -66,6 +66,30 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <c-divider></c-divider>
 
             <div>
+                <l-stack spacing="var(--s-3)">
+                    <c-h3>fill-space</c-h3>
+                    <c-code-sample>
+                        <!-- You will to set the container height with other layout components or in your own way. -->
+                        <div style="height: 300px">
+    <l-center
+        max-width="60ch"
+        text-center.bind="true"
+        fill-space.bind="true"
+    >
+        <l-box
+            background="var(--c_darkGray)"
+            fill-space.bind="true"
+        >
+            I fill all the space that I am put in.
+        </l-box>
+    </l-center>
+</div></c-code-sample>
+                </l-stack>
+            </div>
+
+            <c-divider></c-divider>
+
+            <div>
             	<l-stack spacing="var(--s-3)">
                     <c-h3>max-width</c-h3>
                     <c-code-sample>

--- a/dev-app/routes/layouts/center/index.ts
+++ b/dev-app/routes/layouts/center/index.ts
@@ -36,6 +36,12 @@ export class CenterProperties {
             value: 'boolean',
         },
         {
+            default: 'false',
+            description: 'Set to true if you want height: 100% set on the main center div.',
+            name: 'fill-space',
+            value: 'boolean',
+        },
+        {
             default: 'none',
             description: 'Set the max width size of the centered item.',
             name: 'max-width',

--- a/dev-app/routes/layouts/cover/index.html
+++ b/dev-app/routes/layouts/cover/index.html
@@ -42,7 +42,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                     <div>Sidebar Area</div>
                                 </l-stack>
                             </l-box>
-                            <l-box background="var(--c_darkGray)">
+                            <l-box
+                                background="var(--c_darkGray)"
+                                fill-space.bind="true"
+                            >
                                 <l-cover>
                                     <div>I am at the top</div>
                                     <div data-value="cover">
@@ -75,7 +78,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                     <div>Sidebar Area</div>
                                 </l-stack>
                             </l-box>
-                            <l-box background="var(--c_darkGray)">
+                            <l-box
+                                background="var(--c_darkGray)"
+                                fill-space.bind="true"
+                            >
                                 <l-cover center.bind="true">
                                     <div>I am at the top</div>
                                     <div data-value="cover">
@@ -110,7 +116,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                     <div>Sidebar Area</div>
                                 </l-stack>
                             </l-box>
-                            <l-box background="var(--c_darkGray)">
+                            <l-box
+                                background="var(--c_darkGray)"
+                                fill-space.bind="true"
+                            >
                                 <l-cover padding-top="var(--s3)" padding-bottom="var(--s3)">
                                     <div>I am at the top</div>
                                     <div data-value="cover">
@@ -145,8 +154,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                     <div>Sidebar Area</div>
                                 </l-stack>
                             </l-box>
-                            <l-box background="var(--c_darkGray)">
-                                <l-cover scrolling.bind="true" spacing="medium">
+                            <l-box
+                                background="var(--c_darkGray)"
+                                fill-space.bind="true"
+                            >
+                                <l-cover
+                                    scrolling.bind="true"
+                                    spacing="medium"
+                                >
                                     <div>I am at the top</div>
                                     <div data-value="cover" style="height: 300px; flex: 1 0 0px;">
                                         Setting height on this container will happen from the surrounding layout option.
@@ -198,7 +213,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                     <div>Sidebar Area</div>
                                 </l-stack>
                             </l-box>
-                            <l-box background="var(--c_darkGray)">
+                            <l-box
+                                background="var(--c_darkGray)"
+                                fill-space.bind="true"
+                            >
                                 <l-cover top-gutter="var(--s4)">
                                     <div>I am at the top</div>
                                     <div data-value="cover">

--- a/dev-app/routes/layouts/overview/index.html
+++ b/dev-app/routes/layouts/overview/index.html
@@ -171,6 +171,20 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                         </a>
                     </l-box>
                     <l-box background="var(--c_darkGray)">
+                        <a href="#/layouts/icon">
+                            <l-cover top-gutter="var(--s1)" bottom-gutter="var(--s1)">
+                                <div data-value="cover">
+                                    <l-center max-width="100px" text-center.bind="true">
+                                    <l-icon icon="cog">■■■■</l-icon>
+                                    </l-center>
+                                </div>
+                                <l-center text-center.bind="true">
+                                    <c-h3>Icon</c-h3>
+                                </l-center>
+                            </l-cover>
+                        </a>
+                    </l-box>
+                    <l-box background="var(--c_darkGray)">
                         <a href="#/layouts/sidebar">
                             <l-cover top-gutter="var(--s1)" bottom-gutter="var(--s1)">
                                 <div data-value="cover">

--- a/dev-app/stylesheets/fonts.css
+++ b/dev-app/stylesheets/fonts.css
@@ -10,7 +10,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 /**
  *  HAAS GROTESK DISPLAY
  *  HELVETICA NEUE COND
- *  PROXIMA NOVA
  */
 
 
@@ -67,32 +66,4 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 @font-face{
     font-family: 'HN_67_Cond_It';
     src: url('../assets/fonts/HN67ConIt.woff') format('woff');
-}
-
-
-
-
-
-/*------------------------------------*\
-    !PROXIMA NOVA
-\*------------------------------------*/
-
-@font-face{
-    font-family: 'Proxima_Nova_Reg';
-    src: url('../assets/fonts/ProximaNova-Reg-webfont.woff') format('woff');
-}
-
-@font-face{
-    font-family: 'Proxima_Nova_Reg_Italic';
-    src: url('../assets/fonts/ProximaNova-RegIt-webfont.woff') format('woff');
-}
-
-@font-face{
-    font-family: 'Proxima_Nova_Semi_Bold';
-    src: url('../assets/fonts/ProximaNova-Sbold-webfont.woff') format('woff');
-}
-
-@font-face{
-    font-family: 'Proxima_Nova_Bold';
-    src: url('../assets/fonts/ProximaNova-Bold-webfont.woff') format('woff');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/navs/c-nav-horizontal/c-nav-horizontal.css
+++ b/src/components/navs/c-nav-horizontal/c-nav-horizontal.css
@@ -36,6 +36,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     list-style: none;
 }
 
+.nav-horizontal ul li{
+    text-transform: var(--nav-text-transform);
+}
+
 
 
 

--- a/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
+++ b/src/components/navs/c-nav-horizontal/c-nav-horizontal.html
@@ -11,7 +11,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             ${styles.navHorizontal}
             ${styles[size]}
         "
-        css="--nav-background-color: ${backgroundColor}"
+        css="
+            --nav-background-color: ${backgroundColor};
+            --nav-text-transform: ${textTransform};
+        "
         hide.bind="state === 'hidden'"
     >
         <button

--- a/src/components/navs/c-nav-horizontal/c-nav-horizontal.ts
+++ b/src/components/navs/c-nav-horizontal/c-nav-horizontal.ts
@@ -21,6 +21,8 @@ export class CNavHorizontal {
     public align = 'center';
     @bindable
     public justify = 'start';
+    @bindable
+    public textTransform = 'unset';
 
     public styles = styles;
     public mobileNavOpen;

--- a/src/layouts/l-center/l-center.css
+++ b/src/layouts/l-center/l-center.css
@@ -30,6 +30,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     max-width: var(--center-max-width);
 }
 
+.fill-space,
+.fill-space l-cover{
+    height: 100%;
+}
+
 
 
 

--- a/src/layouts/l-center/l-center.html
+++ b/src/layouts/l-center/l-center.html
@@ -11,6 +11,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             ${styles.center}
             ${intrinsic ? styles.intrinsic : ''}
             ${textCenter ? styles.textCenter : ''}
+            ${fillSpace ? styles.fillSpace : ''}
         "
         css="
             --center-max-width: ${maxWidth};

--- a/src/layouts/l-center/l-center.test.ts
+++ b/src/layouts/l-center/l-center.test.ts
@@ -45,6 +45,22 @@ describe('l-center component', () => {
             }
         });
 
+        it('is fill-space endabled', async done => {
+            component = StageComponent.withResources()
+                .inView('<l-center fill-space.bind="isFillSpace"></l-center>')
+                .boundTo({
+                    isFillSpace: 1,
+                });
+
+            try {
+                await bootStrapEnvironment(component);
+                expect(component.viewModel.fillSpace).toBe(false);
+                done();
+            } catch (e) {
+                done.fail(e);
+            }
+        });
+
         describe('CSS Classes', () => {
             it('css class: center', async done => {
                 component = StageComponent.withResources().inView('<l-center></l-center>');

--- a/src/layouts/l-center/l-center.ts
+++ b/src/layouts/l-center/l-center.ts
@@ -10,6 +10,8 @@ export class LCenter {
     @bindable
     public intrinsic = false;
     @bindable
+    public fillSpace = false;
+    @bindable
     public maxWidth = 'none';
     @bindable
     public spacing = '0';
@@ -25,6 +27,10 @@ export class LCenter {
 
         if (typeof this.textCenter !== 'boolean') {
             this.textCenter = false;
+        }
+
+        if (typeof this.fillSpace !== 'boolean') {
+            this.fillSpace = false;
         }
     }
 }


### PR DESCRIPTION
### What's New
#### c-nav-horizontal
New property `text-transform`. This will allow you to use css to change the text in your nav

#### l-center
New property `fill-space`. This will set height to 100%. This is useful when using it with the l-cover component

#### Doc updates
Include the missing l-icon in the layout overview page

#### Other
Remove unused fonts