### PR TITLE
Header line height

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -58,7 +58,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             </l-box>
         </l-sidebar>
         <router-view data-value="cover"></router-view>
-
         <l-box
             padding-sides="var(--s2)"
             padding-ends="var(--s-3)"

--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.5.1"
+                        title="v1.6.0"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/dev-app/routes/components/type/headlines/index.html
+++ b/dev-app/routes/components/type/headlines/index.html
@@ -9,13 +9,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h2>&lt;c-h1&gt;</c-h2>
                 <c-h3>Properties</c-h3>
-                <c-table cols.bind='h1Cols' rows.bind='h1Properties'></c-table>
+                <c-table
+                    cols.bind='h1Cols'
+                    rows.bind='h1Properties'
+                ></c-table>
                 <c-h4>Theming - .bindable-h1</c-h4>
-                <c-table cols.bind='h1ThemeCols' rows.bind='h1ThemeProperties'></c-table>
+                <c-table
+                    cols.bind='h1ThemeCols'
+                    rows.bind='h1ThemeProperties'
+                ></c-table>
                 <c-code-sample>
                     <c-h1 flush-top.bind="false">Not flush on the top</c-h1>
+                    <c-h1 line-height="5rem">Adjusted line-height</c-h1>
                     <c-h1>Normal Headline 1</c-h1>
-                    <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the end of the line or something. Shrink the width of the browser window if needed.</c-h1>
+                    <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the end of the line
+                        or something. Shrink the width of the browser window if needed.</c-h1>
                     <l-cluster
                         align="flex-start"
                         justify="space-between"
@@ -38,7 +46,9 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                         color="var(--c_lightGray)"
                                         align="0.3em"
                                     ></l-icon>
-                                    <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the end of the line or something. Shrink the width of the browser window if needed.</c-h1>
+                                    <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the
+                                        end of the line or something. Shrink the width of the browser window if needed.
+                                    </c-h1>
                                 </div>
                             </l-cluster>
                             <c-button>Some Button</c-button>
@@ -54,13 +64,22 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h2>&lt;c-h2&gt;</c-h2>
                 <c-h3>Properties</c-h3>
-                <c-table cols.bind='h2Cols' rows.bind='h2Properties'></c-table>
+                <c-table
+                    cols.bind='h2Cols'
+                    rows.bind='h2Properties'
+                ></c-table>
                 <c-h4>Theming - .bindable-h2</c-h4>
-                <c-table cols.bind='h2ThemeCols' rows.bind='h2ThemeProperties'></c-table>
+                <c-table
+                    cols.bind='h2ThemeCols'
+                    rows.bind='h2ThemeProperties'
+                ></c-table>
                 <c-code-sample>
                     <l-grid>
+                        <c-h2 flush-top.bind="false">Not flush on the top</c-h2>
+                        <c-h2 line-height="5rem">Adjusted line-height</c-h2>
                         <c-h2>Headline 2</c-h2>
-                        <c-h2 truncate.bind="true">Headline 2 that is really long and will truncate at the end of the line. Shrink the width of the browser window if needed.</c-h2>
+                        <c-h2 truncate.bind="true">Headline 2 that is really long and will truncate at the end of the
+                            line. Shrink the width of the browser window if needed.</c-h2>
                     </l-grid>
                 </c-code-sample>
             </l-stack>
@@ -72,14 +91,25 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h2>&lt;c-h3&gt;</c-h2>
                 <c-h3>Properties</c-h3>
-                <c-table cols.bind='h3Cols' rows.bind='h3Properties'></c-table>
+                <c-table
+                    cols.bind='h3Cols'
+                    rows.bind='h3Properties'
+                ></c-table>
                 <c-h4>Theming - .bindable-h3</c-h4>
-                <c-table cols.bind='h3ThemeCols' rows.bind='h3ThemeProperties'></c-table>
+                <c-table
+                    cols.bind='h3ThemeCols'
+                    rows.bind='h3ThemeProperties'
+                ></c-table>
                 <c-code-sample>
                     <l-grid>
                         <c-h3>Headline 3</c-h3>
-                        <c-h3 truncate.bind="true">Headline 3 that is really long and will truncate at the end of the line. Shrink the width of the browser window if needed.</c-h3>
-                        <c-h3 truncate.bind="true" dark-back.bind="true">Headline 3 that is really long and will truncate at the end of the line. Shrink the width of the browser window if needed.</c-h3>
+                        <c-h3 truncate.bind="true">Headline 3 that is really long and will truncate at the end of the
+                            line. Shrink the width of the browser window if needed.</c-h3>
+                        <c-h3
+                            truncate.bind="true"
+                            dark-back.bind="true"
+                        >Headline 3 that is really long and will truncate at the end of the line. Shrink the width of
+                            the browser window if needed.</c-h3>
                     </l-grid>
                 </c-code-sample>
             </l-stack>
@@ -91,14 +121,21 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h2>&lt;c-h4&gt;</c-h2>
                 <c-h3>Properties</c-h3>
-                <c-table cols.bind='h4Cols' rows.bind='h4Properties'></c-table>
+                <c-table
+                    cols.bind='h4Cols'
+                    rows.bind='h4Properties'
+                ></c-table>
                 <c-h4>Theming - .bindable-h4</c-h4>
-                <c-table cols.bind='h4ThemeCols' rows.bind='h4ThemeProperties'></c-table>
+                <c-table
+                    cols.bind='h4ThemeCols'
+                    rows.bind='h4ThemeProperties'
+                ></c-table>
                 <c-code-sample>
                     <l-grid>
                         <c-h4>Headline 4</c-h4>
                         <c-h4>Headline 4</c-h4>
-                        <c-h4 truncate.bind="true">Truncated Headline 4 With A Really Long Title So we can see the truncation going on here.</c-h4>
+                        <c-h4 truncate.bind="true">Truncated Headline 4 With A Really Long Title So we can see the
+                            truncation going on here.</c-h4>
                     </l-grid>
                 </c-code-sample>
             </l-stack>
@@ -110,9 +147,15 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             <l-stack spacing="var(--s-3)">
                 <c-h2>&lt;c-h5&gt;</c-h2>
                 <c-h3>Properties</c-h3>
-                <c-table cols.bind='h5Cols' rows.bind='h5Properties'></c-table>
+                <c-table
+                    cols.bind='h5Cols'
+                    rows.bind='h5Properties'
+                ></c-table>
                 <c-h4>Theming - .bindable-h5</c-h4>
-                <c-table cols.bind='h5ThemeCols' rows.bind='h5ThemeProperties'></c-table>
+                <c-table
+                    cols.bind='h5ThemeCols'
+                    rows.bind='h5ThemeProperties'
+                ></c-table>
                 <c-code-sample>
                     <c-h5>Headline 5</c-h5>
                     <c-h5 color="var(--c_smoke)">Headline 5 Smoke Color</c-h5>

--- a/dev-app/routes/components/type/headlines/index.ts
+++ b/dev-app/routes/components/type/headlines/index.ts
@@ -37,6 +37,12 @@ export class Headlines {
             value: 'boolean',
         },
         {
+            default: 'inherit',
+            description: 'Use to set the line-height of the h1',
+            name: 'line-height',
+            value: 'string',
+        },
+        {
             default: 'false',
             description: 'Set if you would like the text to truncate.',
             name: 'truncate',
@@ -121,6 +127,19 @@ export class Headlines {
     ];
 
     public h2Properties = [
+        {
+            default: 'true',
+            description: 'Set to false if you do not want the text to be flush to' +
+            'the top of the container.',
+            name: 'flush-top',
+            value: 'boolean',
+        },
+        {
+            default: 'inherit',
+            description: 'Use to set the line-height of the h2',
+            name: 'line-height',
+            value: 'string',
+        },
         {
             default: 'false',
             description:'Set if you would like the text to truncate.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/type/h1/c-h1.css
+++ b/src/components/type/h1/c-h1.css
@@ -22,6 +22,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 .base{
     margin-top: var(--h1-margin-top);
+    line-height: var(--h1-line-height);
     font-family: var(--h1-font-family);
     font-size: var(--h1-font-size);
     font-weight: normal;

--- a/src/components/type/h1/c-h1.html
+++ b/src/components/type/h1/c-h1.html
@@ -7,6 +7,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-h1.css"></require>
 
     <span class="${truncate ? styles.truncate : ''}  bindable-h1">
-        <h1 class="${styles.base}  ${flushTop ? '' : styles.notFlushTop}"><slot></slot></h1>
+        <h1
+            class="
+                ${styles.base}
+                ${flushTop ? '' : styles.notFlushTop}
+            "
+            css="--h1-line-height: ${lineHeight}"
+        >
+            <slot></slot>
+        </h1>
     </span>
 </template>

--- a/src/components/type/h1/c-h1.ts
+++ b/src/components/type/h1/c-h1.ts
@@ -12,6 +12,8 @@ export class CH1 {
     public flushTop = true;
     @bindable
     public truncate = false;
+    @bindable
+    public lineHeight = 'inherit';
 
     public styles = styles;
 

--- a/src/components/type/h2/c-h2.css
+++ b/src/components/type/h2/c-h2.css
@@ -22,9 +22,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 .base{
     margin-top: var(--h2-margin-top);
+    line-height: var(--h2-line-height);
     font-family: var(--h2-font-family);
     font-size: var(--h2-font-size);
     font-weight: normal;
+}
+
+.not-flush-top{
+    margin-top: initial;
 }
 
 

--- a/src/components/type/h2/c-h2.html
+++ b/src/components/type/h2/c-h2.html
@@ -7,6 +7,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 	<require from="./c-h2.css"></require>
 
     <span class="${truncate ? styles.truncate : ''}  bindable-h2">
-        <h2 class="${styles.base}"><slot></slot></h2>
+        <h2
+            class="
+                ${styles.base}
+                ${flushTop ? '' : styles.notFlushTop}
+            "
+            css="--h2-line-height: ${lineHeight}"
+        >
+            <slot></slot>
+        </h2>
     </span>
 </template>

--- a/src/components/type/h2/c-h2.ts
+++ b/src/components/type/h2/c-h2.ts
@@ -9,13 +9,21 @@ import * as styles from './c-h2.css.json';
 @containerless
 export class CH2 {
     @bindable
+    public flushTop = true;
+    @bindable
     public truncate = false;
+    @bindable
+    public lineHeight = 'inherit';
 
     public styles = styles;
 
     public attached() {
         if (typeof this.truncate !== 'boolean') {
             this.truncate = false;
+        }
+
+        if (typeof this.flushTop !== 'boolean') {
+            this.flushTop = true;
         }
     }
 }


### PR DESCRIPTION
### What's New
#### c-h1
Added the attribute `line-height` to allow for customization of the line-height css attribute.

#### c-h2
Added the attribute `line-height` to allow for customization of the line-height css attribute.
Added the attribute `flush-top` to set the h2 to be flush at the top.