### PR TITLE
zero out spacing on transparent lists

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.6.0"
+                        title="v1.6.1"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/type/list/c-list-container/c-list-container.css
+++ b/src/components/type/list/c-list-container/c-list-container.css
@@ -104,6 +104,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     color: var(--list-container-light-a-icon-hover);
 }
 
+.transparent li:first-child a{
+    padding-top: 0;
+}
+
+.transparent li:last-child a{
+    padding-bottom: 0;
+}
+
 
 /**
  * ^All


### PR DESCRIPTION
### What's Fixed
#### c-list-container
When a list is transparent the spacing on the top and bottom of the list is off from its surroundings. This will make it more uniform.