### PR TITLE
Fix min-height on truncated not flush top c-h1 components

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.7.1"
+                        title="v1.7.2"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/dev-app/routes/components/type/headlines/index.html
+++ b/dev-app/routes/components/type/headlines/index.html
@@ -68,11 +68,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                             >
                                 <div>
                                     <l-icon
+                                        align="0.3em"
                                         icon="chevron-left"
                                         spacing="0"
                                         size="1em"
                                         color="var(--c_lightGray)"
-                                        align="0.9em"
                                     ></l-icon>
                                     <c-h1 truncate.bind="true">Headline 1 that is really long and will truncate at the
                                         end of the line or something. Shrink the width of the browser window if needed.

--- a/dev-app/routes/components/type/headlines/index.ts
+++ b/dev-app/routes/components/type/headlines/index.ts
@@ -91,6 +91,11 @@ export class Headlines {
             property: 'min-height',
         },
         {
+            default: 'var(--s5)',
+            name: '--h1-not-flush-truncate-min-height',
+            property: 'min-height',
+        },
+        {
             default: 'var(--s-1)',
             name: '--h1-truncate-padding-right',
             property: 'padding-right',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/type/h1/c-h1.css
+++ b/src/components/type/h1/c-h1.css
@@ -47,6 +47,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     min-height: var(--h1-truncate-min-height);
 }
 
+.not-flush-truncate{
+    min-height: var(--h1-not-flush-truncate-min-height);
+}
+
 .truncate h1{
     min-width: 0;
     padding-right: var(--h1-truncate-padding-right);

--- a/src/components/type/h1/c-h1.html
+++ b/src/components/type/h1/c-h1.html
@@ -6,7 +6,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
 	<require from="./c-h1.css"></require>
 
-    <span class="${truncate ? styles.truncate : ''}  bindable-h1">
+    <span class="
+            ${truncate ? styles.truncate : ''}
+            ${!flushTop && truncate ? styles.notFlushTruncate : ''}
+            bindable-h1
+        ">
         <h1
             class="
                 ${styles.base}

--- a/src/global-styles/themes/main.css
+++ b/src/global-styles/themes/main.css
@@ -1090,7 +1090,8 @@ c-code{
     --h1-margin-top: -0.55rem;
     --h1-font-family: var(--ff_primary-bold);
     --h1-font-size: var(--s3);
-    --h1-truncate-min-height: var(--s5);
+    --h1-truncate-min-height: var(--s4);
+    --h1-not-flush-truncate-min-height: var(--s5);
     --h1-truncate-padding-right: var(--s-1);
     --h1-truncate-hover-background: var(--c_slate);
 }


### PR DESCRIPTION
### What's Fixed
#### c-h1
When using a c-h1 component that was not flush to the top and could truncate the hover state of the truncated text was off and caused some jittering. This will fix that and allow for users to set new min-height for a truncated c-h1 in their theme.