### PR TITLE
show tile tip all the time

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.7.5"
+                        title="v1.7.6"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/dev-app/routes/components/tile/properties/index.html
+++ b/dev-app/routes/components/tile/properties/index.html
@@ -8,7 +8,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <div>
             <l-stack spacing="var(--s-3)">
                 <c-h2>Properties</c-h2>
-                <c-table cols.bind="tileCols" rows.bind="tileProperties"></c-table>
+                <c-table
+                    cols.bind="tileCols"
+                    rows.bind="tileProperties"
+                ></c-table>
             </l-stack>
         </div>
 
@@ -19,20 +22,92 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 <c-h3>Examples</c-h3>
                 <c-code-sample>
                     <l-grid>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" status="processing" title="Processing Tile"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" color="var(--c_secondaryMain)" title="Title here that is really long so we can see the title truncate and all that n stuff."></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" color="var(--c_subOneMain)" title="Info Tile"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" color="var(--c_subTwoMain)" title="Title wraps but no truncate"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" color="#FF0000" title="aklsdlauneackakjbcnlakjeuybljahbdkfjahbskjbcakjehsb" title-icon="time" show-tip.bind="true" tip-icon="info">
-                            <template replace-part="tip-content"><c-p color="var(--c_white)">Content that replaces the default.</c-p></template>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            status="processing"
+                            title="Processing Tile"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            color="var(--c_secondaryMain)"
+                            title="Title here that is really long so we can see the title truncate and all that n stuff."
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            color="var(--c_subOneMain)"
+                            title="Info Tile"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            color="var(--c_subTwoMain)"
+                            title="Title wraps but no truncate"
+                            always-show-tip-left.bind="true"
+                            tip-icon-left="info"
+                            hover.bind="false"
+                        >
+                            <template replace-part="tip-content-left">
+                                <c-p color="var(--c_white)">Left Tip Content</c-p>
+                            </template>
                         </c-tile>
-                        <c-tile image-url="https://placeimg.com/150/200/any" image-container-height.bind="200" title="Drag Icon" message="Hover Me" show-drag.bind="true"></c-tile>
-                        <c-tile image-url="https://placeimg.com/150/100/any" image-container-height.bind="100" title="Smaller Image"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" title="Regular Image" hover.bind="false" show-checkbox.bind="false"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" title="Disabled State" state="disabled"></c-tile>
-                        <c-tile image-url="" title="No Image URL" image-container-height.bind="100" no-image-message="No Image"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" title="a test string" search-match="a test"></c-tile>
-                        <c-tile image-url="https://placeimg.com/160/200/any" image-container-height.bind="200" title="Pill Item" pill-text="Pill Text"></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            color="#FF0000"
+                            title="aklsdlauneackakjbcnlakjeuybljahbdkfjahbskjbcakjehsb"
+                            title-icon="time"
+                            tip-icon-right="actions"
+                        >
+                            <template replace-part="tip-content-right">
+                                <c-p color="var(--c_white)">Right Tip Content</c-p>
+                            </template>
+                        </c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/150/200/any"
+                            image-container-height.bind="200"
+                            title="Drag Icon"
+                            message="Hover Me"
+                            show-drag.bind="true"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/150/100/any"
+                            image-container-height.bind="100"
+                            title="Smaller Image"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            title="Regular Image"
+                            hover.bind="false"
+                            show-checkbox.bind="false"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            title="Disabled State"
+                            state="disabled"
+                        ></c-tile>
+                        <c-tile
+                            image-url=""
+                            title="No Image URL"
+                            image-container-height.bind="100"
+                            no-image-message="No Image"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            title="a test string"
+                            search-match="a test"
+                        ></c-tile>
+                        <c-tile
+                            image-url="https://placeimg.com/160/200/any"
+                            image-container-height.bind="200"
+                            title="Pill Item"
+                            pill-text="Pill Text"
+                        ></c-tile>
                     </l-grid>
                 </c-code-sample>
             </l-stack>

--- a/dev-app/routes/components/tile/properties/index.ts
+++ b/dev-app/routes/components/tile/properties/index.ts
@@ -92,12 +92,6 @@ export class TileProperties {
             value: 'boolean',
         },
         {
-            default: 'false',
-            description: 'Set to true of you need to have a tip in the tile.',
-            name: 'show-tip',
-            value: 'boolean',
-        },
-        {
             default: '',
             description: 'Highlight search matches',
             name: 'search-match',
@@ -114,9 +108,27 @@ export class TileProperties {
             value: 'processing',
         },
         {
-            default: 'actions',
-            description: 'Set the icon that will trigger a tip.',
-            name: 'tip-icon',
+            default: 'false',
+            description: 'Set to true of you need to have the tip on the left always show. False will show it on hover.',
+            name: 'always-show-tip-left',
+            value: 'boolean',
+        },
+        {
+            default: '',
+            description: 'Set the icon on the left that will trigger a tip.',
+            name: 'tip-icon-left',
+            value: 'Any icon name',
+        },
+        {
+            default: 'false',
+            description: 'Set to true of you need to have the tip on the right always show. False will show it on hover.',
+            name: 'always-show-tip-right',
+            value: 'boolean',
+        },
+        {
+            default: '',
+            description: 'Set the icon on the right that will trigger a tip.',
+            name: 'tip-icon-right',
             value: 'Any icon name',
         },
         {

--- a/dev-app/routes/components/tile/replaceable-parts/index.html
+++ b/dev-app/routes/components/tile/replaceable-parts/index.html
@@ -8,7 +8,10 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         <div>
             <l-stack spacing="var(--s-3)">
                 <c-h2>Replaceable Parts</c-h2>
-                <c-table cols.bind="tileCols" rows.bind="tileReplaceableParts"></c-table>
+                <c-table
+                    cols.bind="tileCols"
+                    rows.bind="tileReplaceableParts"
+                ></c-table>
             </l-stack>
         </div>
 
@@ -19,9 +22,18 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                 <c-h3>tip-content</c-h3>
                 <c-code-sample>
                     <l-grid>
-                        <c-tile image-url="https://placeimg.com/250/190/any" image-container-height.bind="190" title="Regular Tile" show-tip.bind="true">
-                            <template replace-part="tip-content">
-                                <c-list-container color="transparent" size="small">
+                        <c-tile
+                            image-url="https://placeimg.com/250/190/any"
+                            image-container-height.bind="190"
+                            title="Regular Tile"
+                            always-show-tip-right.bind="true"
+                            tip-icon-right="actions"
+                        >
+                            <template replace-part="tip-content-right">
+                                <c-list-container
+                                    color="transparent"
+                                    size="small"
+                                >
                                     <c-list-item>
                                         <a href="#">
                                             <l-icon
@@ -69,8 +81,14 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                                 </c-list-container>
                             </template>
                         </c-tile>
-                        <c-tile image-url="https://placeimg.com/250/190/any" image-container-height.bind="190" title="Drag Icon" message="Hover Me" show-drag.bind="true" show-tip.bind="true">
-                            <template replace-part="tip-content">Custom Tip Content</template>
+                        <c-tile
+                            image-url="https://placeimg.com/250/190/any"
+                            image-container-height.bind="190"
+                            title="Drag Icon"
+                            message="Hover Me"
+                            tip-icon-left="info"
+                        >
+                            <template replace-part="tip-content-left">Left Tip Content</template>
                         </c-tile>
                     </l-grid>
                 </c-code-sample>

--- a/dev-app/routes/components/tile/replaceable-parts/index.ts
+++ b/dev-app/routes/components/tile/replaceable-parts/index.ts
@@ -25,8 +25,13 @@ export class TileReplaceableParts {
 
     public tileReplaceableParts = [
         {
-            description: 'Set what you want to go in the tip.',
-            name: 'tip-content',
+            description: 'Set what you want to go in the left tip.',
+            name: 'tip-content-left',
+            value: 'Text or other components',
+        },
+        {
+            description: 'Set what you want to go in the right tip.',
+            name: 'tip-content-right',
             value: 'Text or other components',
         },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/tile/c-tile/c-tile.css
+++ b/src/components/tile/c-tile/c-tile.css
@@ -200,13 +200,12 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     right: var(--tile-tip-right);
     padding: var(--tile-tip-padding);
     z-index: var(--z_tileTip);
-    background: var(--tile-tip-background);
-    opacity: 0;
-    transition: var(--trans_main) background, var(--trans_main) opacity;
+    background: var(--tile-background);
+    transition: var(--trans_main) background;
 }
 
 .tile:hover .tip{
-    opacity: 1;
+    background: var(--tile-background-hover);
 }
 
 .tip:hover{

--- a/src/components/tile/c-tile/c-tile.css
+++ b/src/components/tile/c-tile/c-tile.css
@@ -197,20 +197,34 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .tip{
     position: absolute;
     top: var(--tile-tip-top);
-    right: var(--tile-tip-right);
     padding: var(--tile-tip-padding);
     z-index: var(--z_tileTip);
     background: var(--tile-background);
-    transition: var(--trans_main) background;
+    opacity: 0;
+    transition: var(--trans_main) background, var(--trans_main) opacity;
 }
 
-.tile:hover .tip{
+.always-show{
+    opacity: 1;
+}
+
+.tip-right{
+    right: var(--tile-tip-right);
+}
+
+.tip-left{
+    left: var(--tile-tip-left);
+}
+
+.hover:hover .tip{
+    opacity: 1;
     background: var(--tile-background-hover);
 }
 
 .tip:hover{
     cursor: pointer;
 }
+
 
 
 

--- a/src/components/tile/c-tile/c-tile.html
+++ b/src/components/tile/c-tile/c-tile.html
@@ -4,7 +4,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 -->
 
 <template>
-	<require from="./c-tile.css"></require>
+    <require from="./c-tile.css"></require>
 
     <div
         class="
@@ -20,21 +20,49 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
             class="${styles.container}"
         >
             <c-tip
-                side="left"
+                side="right"
                 size="small"
                 icon-tip.bind="true"
-                class="${styles.tip}"
-                if.bind="showTip"
+                class="
+                    ${styles.tip}
+                    ${styles.tipLeft}
+                    ${alwaysShowTipLeft ? styles.alwaysShow : ''}
+                "
+                if.bind="tipIconLeft"
             >
                 <div slot="trigger">
                     <l-icon
-                        icon="${tipIcon}"
+                        icon="${tipIconLeft}"
                         spacing="0"
                     ></l-icon>
                 </div>
                 <div slot="content">
                     <template
-                        part="tip-content"
+                        part="tip-content-left"
+                        replaceable
+                    ></template>
+                </div>
+            </c-tip>
+            <c-tip
+                side="left"
+                size="small"
+                icon-tip.bind="true"
+                class="
+                    ${styles.tip}
+                    ${styles.tipRight}
+                    ${alwaysShowTipRight ? styles.alwaysShow : ''}
+                "
+                if.bind="tipIconRight"
+            >
+                <div slot="trigger">
+                    <l-icon
+                        icon="${tipIconRight}"
+                        spacing="0"
+                    ></l-icon>
+                </div>
+                <div slot="content">
+                    <template
+                        part="tip-content-right"
                         replaceable
                     ></template>
                 </div>
@@ -92,9 +120,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                             truncate.bind="true"
                             click.trigger="showCheckbox && state !== 'disabled' ? checkedValue = !checkedValue : ''"
                         >
-                            <l-icon
-                                icon="${titleIcon}"
-                            >
+                            <l-icon icon="${titleIcon}">
                                 <span if.bind="!searchHighlight">${title}</span>
                                 <span
                                     if.bind="searchHighlight"

--- a/src/components/tile/c-tile/c-tile.ts
+++ b/src/components/tile/c-tile/c-tile.ts
@@ -43,15 +43,19 @@ export class CTile {
     @bindable
     public showDrag = false;
     @bindable
-    public showTip = false;
-    @bindable
     public state;
     @bindable
     public status;
     @bindable
     public color;
     @bindable
-    public tipIcon = 'actions';
+    public alwaysShowTipLeft = false;
+    @bindable
+    public tipIconLeft;
+    @bindable
+    public alwaysShowTipRight = false;
+    @bindable
+    public tipIconRight;
     @bindable
     public title;
     @bindable
@@ -74,8 +78,12 @@ export class CTile {
             this.showDrag = false;
         }
 
-        if (typeof this.showTip !== 'boolean') {
-            this.showTip = false;
+        if (typeof this.alwaysShowTipRight !== 'boolean') {
+            this.alwaysShowTipRight = false;
+        }
+
+        if (typeof this.alwaysShowTipLeft !== 'boolean') {
+            this.alwaysShowTipLeft = false;
         }
 
         if (typeof this.imageContainerHeight !== 'number') {

--- a/src/global-styles/themes/main.css
+++ b/src/global-styles/themes/main.css
@@ -916,7 +916,8 @@ c-tile{
     /* tip */
     --tile-tip-top: calc(var(--s-5) * -1);
     --tile-tip-right: calc(var(--s-5) * -1);
-    --tile-tip-padding: var(--s-5) var(--s-3);
+    --tile-tip-left: calc(var(--s-5) * -1);
+    --tile-tip-padding: var(--s-5) var(--s-2);
 
     /* status */
     --tile-status-height: var(--s-5);

--- a/src/global-styles/themes/main.css
+++ b/src/global-styles/themes/main.css
@@ -917,7 +917,6 @@ c-tile{
     --tile-tip-top: calc(var(--s-5) * -1);
     --tile-tip-right: calc(var(--s-5) * -1);
     --tile-tip-padding: var(--s-5) var(--s-3);
-    --tile-tip-background: var(--c_charcoal);
 
     /* status */
     --tile-status-height: var(--s-5);


### PR DESCRIPTION
### What's Changed
#### c-tile
Before you could only have an icon with tip on the right side of the tile. It would only show on hover. 

Now you can set an icon-tip to be on the right or left side or both and set that icon to always show or show on hover.

##### New Props
`alwaysShowTipLeft` : `boolean`
`tipIconLeft` : `string` (icon name)
`alwaysShowTipRight` : `boolean`
`tipIconRight` : `string` (icon name)

##### New Replaceable Part
`tip-content-left`
`tip-content-right`

##### Removed Props
`tip-icon`
`show-tip`

##### Removed Replaceable Part
`tip-content`