### PR TITLE
fix for checkbox/radio long label wrapping

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.8.0"
+                        title="v1.8.1"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.css
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-input/c-checkbox-input.css
@@ -29,6 +29,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .check{
     width: var(--checkbox-size) !important;
     height: var(--checkbox-size) !important;
+    flex: 0 0 var(--checkbox-size);
+    margin-top: var(--checkbox-margin-top) !important;
     border: var(--checkbox-border);
     border-radius: var(--checkbox-border-radius);
     outline: none;

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.css
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.css
@@ -30,7 +30,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     color: var(--radio-checkbox-label-color);
     font-size: var(--radio-checkbox-label-size);
     cursor: pointer;
-    line-height: 0;
 }
 
 

--- a/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
@@ -10,7 +10,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         show.bind="_state !== 'hidden'"
         drag-dropzone.bind="dropOptions"
     >
-        <l-cluster spacing="var(--s-5)">
+        <l-cluster
+            align="flex-start"
+            spacing="var(--s-5)"
+            wrap.bind="false"
+        >
             <div>
                 <c-drag-handle
                     if.bind="draggable && _state !== 'disabled'"

--- a/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
+++ b/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
@@ -5,7 +5,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 <template>
     <div show.bind="_state !== 'hidden'">
-        <l-cluster spacing="var(--s-5)">
+        <l-cluster
+            align="flex-start"
+            spacing="var(--s-5)"
+            wrap.bind="false"
+        >
             <div>
                 <c-radio-input
                     name="${name}"

--- a/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.css
+++ b/src/components/forms/checkbox-radio/radio/c-radio-input/c-radio-input.css
@@ -29,6 +29,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 .radio{
     width: var(--radio-size) !important;
     height: var(--radio-size) !important;
+    flex: 0 0 var(--radio-size);
+    margin-top: var(--radio-margin-top) !important;
     border: var(--radio-border);
     border-radius: 50%;
     outline: none;

--- a/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.css
+++ b/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.css
@@ -30,7 +30,6 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     color: var(--radio-checkbox-label-color);
     font-size: var(--radio-checkbox-label-size);
     cursor: pointer;
-    line-height: 0;
 }
 
 

--- a/src/components/forms/checkbox-radio/toggle/c-form-toggle/c-form-toggle.css
+++ b/src/components/forms/checkbox-radio/toggle/c-form-toggle/c-form-toggle.css
@@ -21,7 +21,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
 .base{
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
 }
 
 td .base{

--- a/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.css
+++ b/src/components/forms/checkbox-radio/toggle/c-toggle-input/c-toggle-input.css
@@ -34,6 +34,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     position: relative;
     width: var(--s2);
     height: var(--s0);
+    flex: 0 0 var(--s2);
     margin: calc(var(--s-5) - 3px) var(--s0) calc(var(--s-5) - 3px) var(--s-5);
     display: inline-block;
     cursor: pointer;

--- a/src/global-styles/themes/main.css
+++ b/src/global-styles/themes/main.css
@@ -431,6 +431,7 @@ c-tile,
 c-table{
     /* checkbox */
     --checkbox-size: var(--s0);
+    --checkbox-margin-top: 4px;
     --checkbox-border: solid 1px var(--c_black);
     --checkbox-border-radius: 2px;
     --checkbox-background: var(--c_charcoal);
@@ -441,6 +442,7 @@ c-table{
 
     /* radio */
     --radio-size: var(--s0);
+    --radio-margin-top: 3.5px;
     --radio-border: solid 1px var(--c_black);
     --radio-background: var(--c_charcoal);
     --radio-hover-background: var(--c_gray);


### PR DESCRIPTION
### Bug Fix
#### If a checkbox or radio label was so long it wrapped the label became un-readable. This fixes that and will cause it to wrap appropriately. 