### PR TITLE
Add align to c-form-checkbox and radio and text-align center to c-table

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.8.2"
+                        title="v1.8.3"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/dev-app/routes/components/forms/checkbox/properties/index.ts
+++ b/dev-app/routes/components/forms/checkbox/properties/index.ts
@@ -19,7 +19,6 @@ export class CheckboxProperties {
         },
         {
             _class: 'monospaced',
-            colClass: 't240',
             colHeadName: 'value',
             colHeadValue: 'Value',
         },
@@ -34,6 +33,12 @@ export class CheckboxProperties {
     ];
 
     public formCheckboxProperties = [
+        {
+            default: 'flex-start',
+            description: 'Flexbox alignment of the checkbox with the label.',
+            name: 'align',
+            value: 'center | flex-start | flex-end | stretch | baseline',
+        },
         {
             description: 'Sets the value of the checkbox.',
             name: 'checked-value',

--- a/dev-app/routes/components/forms/radio/properties/index.ts
+++ b/dev-app/routes/components/forms/radio/properties/index.ts
@@ -17,7 +17,6 @@ export class RadioProperties {
         },
         {
             _class: 'monospaced',
-            colClass: 't240',
             colHeadName: 'value',
             colHeadValue: 'Value',
         },
@@ -28,6 +27,12 @@ export class RadioProperties {
     ];
 
     public formRadioProperties = [
+        {
+            default: 'flex-start',
+            description: 'Flexbox alignment of the radio with the label.',
+            name: 'align',
+            value: 'center | flex-start | flex-end | stretch | baseline',
+        },
         {
             description: '',
             name: 'checked',

--- a/dev-app/routes/components/tables/table/cols-and-rows/index.ts
+++ b/dev-app/routes/components/tables/table/cols-and-rows/index.ts
@@ -118,7 +118,7 @@ export class TableColsRows {
             {
                 description: 'Set a class for specific use cases.',
                 key: '_class',
-                value: 'textInput, monospaced, alighRight, active, bgHealthy, bgWarning, bgCritical, ' +
+                value: 'textInput, monospaced, alighRight, alignCenter, active, bgHealthy, bgWarning, bgCritical, ' +
                 'bgInfo, bgProcess, footer, dragCheck, button',
             },
             {
@@ -420,7 +420,7 @@ export class TableColsRows {
             {
                 description: 'Set a class for specific use cases.',
                 key: '_class',
-                value: 'textInput, monospaced, alighRight, active, bgHealthy, bgWarning, bgCritical, bgInfo, ' +
+                value: 'textInput, monospaced, alighRight, alignCenter, active, bgHealthy, bgWarning, bgCritical, bgInfo, ' +
                 'bgProcess, footer',
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.css
+++ b/src/components/forms/checkbox-radio/checkbox/c-checkbox-label/c-checkbox-label.css
@@ -32,6 +32,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     cursor: pointer;
 }
 
+.label select{
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+
 
 
 

--- a/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
+++ b/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.html
@@ -11,11 +11,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
         drag-dropzone.bind="dropOptions"
     >
         <l-cluster
-            align="flex-start"
+            align="${align}"
             spacing="var(--s-5)"
             wrap.bind="false"
         >
-            <div>
+            <div css="
+                ${align === 'center' ? '--checkbox-margin-top: calc(var(--cluster-spacing)/2) !important' : ''};
+            ">
                 <c-drag-handle
                     if.bind="draggable && _state !== 'disabled'"
                     class="${styles.draggable}"

--- a/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.ts
+++ b/src/components/forms/checkbox-radio/checkbox/c-form-checkbox/c-form-checkbox.ts
@@ -11,6 +11,8 @@ import * as styles from './c-form-checkbox.css.json';
 @authState
 @containerless
 export class CFormCheckbox {
+    @bindable
+    public align = 'flex-start';
     @bindable({defaultBindingMode: bindingMode.twoWay})
     public checkedValue;
     @bindable

--- a/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
+++ b/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.html
@@ -6,11 +6,13 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 <template>
     <div show.bind="_state !== 'hidden'">
         <l-cluster
-            align="flex-start"
+            align="${align}"
             spacing="var(--s-5)"
             wrap.bind="false"
         >
-            <div>
+            <div css="
+                ${align === 'center' ? '--radio-margin-top: calc(var(--cluster-spacing)/2) !important' : ''};
+            ">
                 <c-radio-input
                     name="${name}"
                     id="${id}"

--- a/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.ts
+++ b/src/components/forms/checkbox-radio/radio/c-form-radio/c-form-radio.ts
@@ -10,6 +10,8 @@ import {authState} from '../../../../../decorators/auth-state';
 export class CFormRadio {
     @bindable
     public actions;
+    @bindable
+    public align = 'flex-start';
     @bindable({defaultBindingMode: bindingMode.twoWay})
     public checked;
     @bindable

--- a/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.css
+++ b/src/components/forms/checkbox-radio/radio/c-radio-label/c-radio-label.css
@@ -32,6 +32,11 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
     cursor: pointer;
 }
 
+.label select{
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+
 
 
 

--- a/src/components/tables/c-table/c-table.css
+++ b/src/components/tables/c-table/c-table.css
@@ -24,7 +24,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
  *  TEXT INPUT
  *  DRAG
  *  TD BACKGROUND
- *  ALIGN RIGHT
+ *  ALIGN
  *  SORT
  *  RESPONSIVE
  */
@@ -415,11 +415,15 @@ td.bg-building{
 
 
 /*------------------------------------*\
-    !ALIGN RIGHT
+    !ALIGN
 \*------------------------------------*/
 
 .align-right{
     text-align: right !important;
+}
+
+.align-center{
+    text-align: center !important;
 }
 
 
@@ -442,17 +446,14 @@ c-table-fixed-header .sort{
 }
 
 .sort-none{
-    composes: sort;
     background-image: var(--table-sort-icon-none);
 }
 
 .sort-desc{
-    composes: sort;
     background-image: var(--table-sort-icon-desc);
 }
 
 .sort-asc{
-    composes: sort;
     background-image: var(--table-sort-icon-asc);
 }
 


### PR DESCRIPTION
### What's New
#### c-form-checkbox & c-form-radio
new `align` property
This new property will change how the flex align-items will align the checkbox/radio with the label.

#### c-table
Add a new class for aligning text in the center of a cell.