### PR TITLE
fix for table sort icon position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/tables/c-table/c-table.css
+++ b/src/components/tables/c-table/c-table.css
@@ -446,14 +446,17 @@ c-table-fixed-header .sort{
 }
 
 .sort-none{
+    composes: sort;
     background-image: var(--table-sort-icon-none);
 }
 
 .sort-desc{
+    composes: sort;
     background-image: var(--table-sort-icon-desc);
 }
 
 .sort-asc{
+    composes: sort;
     background-image: var(--table-sort-icon-asc);
 }
 


### PR DESCRIPTION
### What's Fixed
The position of the sort icon on tables got messed up with a previous release. This will fix it.