### PR TITLE
Add special character support to highlight text helper

### DIFF
--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -52,7 +52,7 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
                     <c-nav-horizontal-item
                         position="right"
                         href="https://github.com/bindable-ui/bindable"
-                        title="v1.10.1"
+                        title="v1.10.2"
                     ></c-nav-horizontal-item>
                 </c-nav-horizontal>
             </l-box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bindable-ui/bindable",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/helpers/highlight-text.ts
+++ b/src/helpers/highlight-text.ts
@@ -1,15 +1,9 @@
-/*
-Copyright 2020, Verizon Media
-Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
-*/
-
 export const highlightSearchText = (search: string, matchAgainst?: string): string => {
     let title = matchAgainst || '';
     title = title
+        .replace('&', '&amp;')
         .replace('<', '&lt;')
-        .replace('>', '&gt;')
-        .replace('&', '&amp;');
-
+        .replace('>', '&gt;');
     if (search && search.length > 0) {
         // iterate over each part of the search term - have to do the search in two steps: find
         // all matches for all terms and /then/ replace them with highlighted versions,
@@ -17,21 +11,27 @@ export const highlightSearchText = (search: string, matchAgainst?: string): stri
         // (e.g. if the user searched for 'm a', the 'a' term would match
         // '<span class="searchTerm">m</span>s added after searching for 'm').
         const repls = [];
-        const parts = search.split(' ');
+        const query = search
+            .replace('&', '&amp;')
+            .replace('<', '&lt;')
+            .replace('>', '&gt;');
+        const parts = query.split(' ');
         parts.forEach(part => {
-            const repl = function foo(orig) {
-                const index = repls.length;
+            function escapeRegex(str: string) {
+                return str.replace(/[-\/\\^$*+?.:()|[\]{}]/g, '\\$&');
+            }
+            const repl = function foo(orig: string) {
                 repls.push(orig);
-                return `^^${index}^^`;
+                return `<${orig}>`;
             };
             if (part.length) {
-                title = title.replace(new RegExp(part, 'ig'), repl);
+                title = title.replace(new RegExp(escapeRegex(part), 'ig'), repl);
             }
         });
 
         // go back and insert the highlight spans
-        repls.forEach((orig, i) => {
-            title = title.replace(`^^${i}^^`, `<span style="background-color: #226684;">${orig}</span>`);
+        repls.forEach(orig => {
+            title = title.replace(`<${orig}>`, `<span style="background-color: #226684;">${orig}</span>`);
         });
     }
     return title;


### PR DESCRIPTION
This PR improves support for special characters within highlighted search text. 
![image](https://user-images.githubusercontent.com/224166/155772355-1dbc0aaf-3226-4b20-bbdb-0ae26cc0e667.png)

Without these code changes, search queries against strings including special characters such as "|" would display garbled, such as in the following screenshot:
![image](https://user-images.githubusercontent.com/224166/155772201-878fe4dc-8744-4747-96bd-c2d6ace74251.png)

