### PR TITLE
Feature/td drag only

### DIFF
--- a/dev-app/routes/components/tables/table/views-and-view-models/index.html
+++ b/dev-app/routes/components/tables/table/views-and-view-models/index.html
@@ -17,6 +17,8 @@ Licensed under the terms of the MIT license. See the LICENSE file in the project
 
         <c-divider></c-divider>
 
+
+
         <div>
             <l-stack spacing="var(--s-3)">
                 <c-h3>c-td-button</c-h3>
@@ -370,54 +372,53 @@ this.checkboxData = [
 
         <div>
             <l-stack spacing="var(--s-3)">
-                <c-h3>c-drag-handle</c-h3>
-                <c-code>this.dragHandleCols = [
-    {
-        colClass: 't30',
-        colHeadValue: '',
-        colHeadName: 'drag',
-        _class: 'drag',
-        view: PLATFORM.moduleName('@bindable-ui/bindable/components/utilities/c-drag-handle/c-drag-handle.html'),
-        viewModel: PLATFORM.moduleName('@bindable-ui/bindable/components/utilities/c-drag-handle/c-drag-handle'),
-    },
-    {
-        colHeadValue: 'Ship',
-        colHeadName: 'ship',
-        sort: true,
-    },
-    {
-        colClass: 't50',
-        colHeadValue: 'Gender',
-        colHeadName: 'gender',
-    },
-];
+                <c-h3>c-td-drag</c-h3>
+                <c-code>this.dragCols = [
+                    {
+                        colClass: 't30',
+                        colHeadValue: '',
+                        colHeadName: 'drag',
+                        _class: 'drag',
+                        view: PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag.html'),
+                        viewModel: PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag'),
+                    },
+                    {
+                        colHeadValue: 'Ship',
+                        colHeadName: 'ship',
+                        sort: true,
+                    },
+                    {
+                        colClass: 't50',
+                        colHeadValue: 'Order',
+                        colHeadName: 'order',
+                    },
+                ];
 
-this.dragHandleData = [
-    {
-        ship: 'X-Wing',
-        gender: 'Male',
-    },
-    {
-        _barColor: 'var(--c_subFourMain)',
-        _status: 'bar',
-        ship: 'M. Falcon',
-        gender: 'Male',
-    },
-    {
-        ship: 'Tie Fighter',
-        gender: 'Male',
-    },
-    {
-        name: 'Rey',
-        ship: 'M. Falcon',
-        gender: 'Female',
-    },
+                this.dragCheckData = [
+                    {
+                        ship: 'X-Wing',
+                        order: 1,
+                    },
+                    {
+                        ship: 'M. Falcon',
+                        order: 2,
+                    },
+                    {
+                        _barColor: 'var(--c_subFourMain)',
+                        _status: 'bar',
+                        ship: 'Tie Fighter',
+                        order: 3,
+                    },
+                    {
+                        ship: 'M. Falcon',
+                        order: 4,
+                    },
 ];</c-code>
                 <c-code-sample>
                     <c-table
-                        cols.bind="dragHandleCols"
-                        rows.bind="dragHandleData"
-                        actions.bind="tableActionsSample"
+                        cols.bind="dragCols"
+                        rows.bind="dragData"
+                        row-dropzone-actions.bind="dragDropActions"
                         hover.bind="true"
                     ></c-table>
                 </c-code-sample>
@@ -483,7 +484,7 @@ this.dragCheckData = [
                         actions.bind="tableActionsSample2"
                         cols.bind="dragCheckCols"
                         rows.bind="dragCheckData"
-                        row-dropzone-actions.bind="dropzoneActions"
+                        row-dropzone-actions.bind="dragCheckDropActions"
                         hover.bind="true"
                     ></c-table>
                 </c-code-sample>

--- a/dev-app/routes/components/tables/table/views-and-view-models/index.ts
+++ b/dev-app/routes/components/tables/table/views-and-view-models/index.ts
@@ -25,6 +25,8 @@ export class TableViews {
     public dragHandleData;
     public dragCheckCols;
     public dragCheckData;
+    public dragCols;
+    public dragData;
     public pillTableCols;
     public pillTableData;
     public actionTableCols;
@@ -172,22 +174,21 @@ export class TableViews {
             },
             {
                 description: 'Set to place c-drag-handle in a cell.',
-                name: 'c-drag-handle',
+                name: 'c-td-drag',
                 type: 'view',
-                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/utilities/c-drag-handle/c-drag-handle.html')",
+                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag.html')",
             },
             {
                 description: '',
                 name: '',
                 type: 'viewModel',
-                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/utilities/c-drag-handle/c-drag-handle.html')",
+                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag')",
             },
             {
                 description: 'Set to place c-checkbox-input and a drag in a cell.',
                 name: 'c-td-drag-check',
                 type: 'view',
-                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag-check/c-td-drag-check" +
-                ".html')",
+                value: "PLATFORM.moduleName('@bindable-ui/bindable/components/tables/td-contents/c-td-drag-check/c-td-drag-check.html')",
             },
             {
                 description: '',
@@ -585,6 +586,72 @@ export class TableViews {
         ];
 
         // drag handle checkbox example
+        this.dragCols = [
+            {
+                _class: 'drag',
+                colClass: 't30',
+                colHeadName: 'drag',
+                colHeadValue: '',
+                getDragOptions: (row): IDragOptions => {
+                    return {
+                        dragData: (event) => {
+                            const trEl = this.findParentByType(event.target, 'TR');
+                            trEl.style.opacity = '0.4';
+                            return row;
+                        },
+                        getDragTarget: (target) => {
+                            return this.findParentByType(target, 'TR');
+                        },
+
+                        onDragEnd: (event) => {
+                            const trEl = this.findParentByType(event.target, 'TR');
+                            trEl.style.opacity = '1';
+                            return false;
+                        },
+
+                    };
+                },
+                view: PLATFORM.moduleName(
+                    '@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag.html',
+                ),
+                viewModel: PLATFORM.moduleName(
+                    '@bindable-ui/bindable/components/tables/td-contents/c-td-drag/c-td-drag',
+                ),
+            },
+            {
+                colHeadName: 'ship',
+                colHeadValue: 'Ship',
+                sort: true,
+            },
+            {
+                colHeadName: 'order',
+                colHeadValue: 'Order',
+                sort: false,
+            },
+        ];
+
+        this.dragData = [
+            {
+                order: 1,
+                ship: 'X-Wing',
+            },
+            {
+                order: 2,
+                ship: 'M. Falcon',
+            },
+            {
+                _barColor: 'var(--c_subFourMain)',
+                _status: 'bar',
+                order: 3,
+                ship: 'Tie Fighter',
+            },
+            {
+                order: 4,
+                ship: 'Star Destroyer',
+            },
+        ];
+
+        // drag handle checkbox example
         this.dragCheckCols = [
             {
                 _class: 'dragCheck',
@@ -800,7 +867,7 @@ export class TableViews {
         },
     ];
 
-    public dropzoneActions = (row) => {
+    public dragCheckDropActions = (row) => {
         const self = this;
 
         return {
@@ -817,6 +884,27 @@ export class TableViews {
                 target.style.border = '';
 
                 self.dragCheckData = sortDropData(data, row, self.dragCheckData, 'order');
+            },
+        };
+    }
+
+    public dragDropActions = (row) => {
+        const self = this;
+
+        return {
+            onDragEnter(event) {
+                const target = self.findParentByType(event.target, 'TR');
+                target.style.border = '2px dashed red';
+            },
+            onDragLeave(event) {
+                const target = self.findParentByType(event.target, 'TR');
+                target.style.border = '';
+            },
+            onDrop(event, data) {
+                const target = self.findParentByType(event.target, 'TR');
+                target.style.border = '';
+
+                self.dragData = sortDropData(data, row, self.dragData, 'order');
             },
         };
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bindable-ui/bindable",
   "description": "An Aurelia component library",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bindable-ui/bindable"

--- a/src/components/tables/c-table/c-table.css
+++ b/src/components/tables/c-table/c-table.css
@@ -373,31 +373,46 @@ td.button {
 
 
 
-
-
 /*------------------------------------*\
     !DRAG
 \*------------------------------------*/
 
-.drag,
+.drag {
+    position: relative;
+}
+
+.drag compose c-drag-handle>span {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+}
+
+.drag compose c-drag-handle l-icon {
+    line-height: 1;
+    align-self: center;
+}
+
+.drag compose c-drag-handle>span:hover {
+    background: var(--table-drag-background-hover);
+}
+
+
+/*------------------------------------*\
+    !DRAG-CHECK
+\*------------------------------------*/
+
 .drag-check c-drag-handle {
     position: relative;
 }
 
-.drag compose span,
 .drag-check compose span {
     position: absolute;
     transition: background var(--trans_main), opacity var(--trans_main);
-}
-
-.drag compose>span>l-icon>span {
-    top: var(--table-drag-top);
-    left: var(--table-drag-left);
-    line-height: 0;
-    height: var(--table-drag-height);
-    padding-top: var(--table-drag-padding-top);
-    padding-right: var(--table-drag-padding-right);
-    padding-left: var(--table-drag-padding-left);
 }
 
 .drag-check compose c-drag-handle>span>l-icon>span {
@@ -409,21 +424,19 @@ td.button {
     padding-left: var(--table-drag-check-padding-left);
 }
 
-.drag compose l-icon span:hover,
 .drag-check compose l-icon span:hover {
     background: var(--table-drag-background-hover);
 }
 
-.drag input[type=checkbox],
 .drag-check input[type=checkbox] {
     margin-left: 0;
 }
 
-.table tbody td c-drag-handle>span {
+.table tbody td.drag-check c-drag-handle>span {
     opacity: 0;
 }
 
-.table tbody tr:hover td c-drag-handle>span {
+.table tbody tr:hover td.drag-check c-drag-handle>span {
     opacity: 1;
 }
 

--- a/src/components/tables/td-contents/c-td-drag/c-td-drag.html
+++ b/src/components/tables/td-contents/c-td-drag/c-td-drag.html
@@ -1,0 +1,8 @@
+<!--
+Copyright 2020, Verizon Media
+Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
+-->
+
+<template>
+    <c-drag-handle drag-options.bind="col.getDragOptions(row)"></c-drag-handle>
+</template>

--- a/src/components/tables/td-contents/c-td-drag/c-td-drag.test.ts
+++ b/src/components/tables/td-contents/c-td-drag/c-td-drag.test.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2020, Verizon Media
+Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
+*/
+
+import {StageComponent} from 'aurelia-testing';
+
+describe('c-td-drag component', () => {
+    let component;
+
+    describe('Integration', () => {
+        // Base Test
+        it('testing for drag components', async done => {
+            component = StageComponent.withResources().inView('<c-td-drag></c-td-drag>');
+
+            try {
+                await bootStrapEnvironment(component);
+                expect(document.querySelector('c-drag-handle')).toBeDefined();
+                done();
+            } catch (e) {
+                done.fail(e);
+            }
+        });
+    });
+});

--- a/src/components/tables/td-contents/c-td-drag/c-td-drag.ts
+++ b/src/components/tables/td-contents/c-td-drag/c-td-drag.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2020, Verizon Media
+Licensed under the terms of the MIT license. See the LICENSE file in the project root for license terms.
+*/
+
+import {inject, observable} from 'aurelia-framework';
+
+@inject(Element)
+export class CTdDrag {
+    @observable
+    public value;
+    public element = null;
+    public image = null;
+    public row = null;
+    public col = null;
+
+    public dragOptions = {
+        dragData: () => ({id: this.row.id, type: 'asset'}),
+        thumbnailSrc: () => {
+            if (this.col && this.col.dragSource) {
+                return this.col.dragSource(this.row);
+            }
+
+            return null;
+        },
+    };
+
+    constructor(element) {
+        this.element = element;
+    }
+
+    public activate(model) {
+        this.value = model.value;
+        this.row = model.row;
+        this.col = model.col;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ export function configure(config: FrameworkConfiguration) {
         PLATFORM.moduleName('./components/tables/td-contents/c-td-button/c-td-button'),
         PLATFORM.moduleName('./components/tables/td-contents/c-td-action/c-td-action'),
         PLATFORM.moduleName('./components/tables/td-contents/c-td-check/c-td-check'),
+        PLATFORM.moduleName('./components/tables/td-contents/c-td-drag/c-td-drag'),
         PLATFORM.moduleName('./components/tables/td-contents/c-td-drag-check/c-td-drag-check'),
         PLATFORM.moduleName('./components/tables/td-contents/c-td-image/c-td-image'),
         PLATFORM.moduleName('./components/tables/td-contents/c-td-pill/c-td-pill'),


### PR DESCRIPTION
Adding new td-drag component separate from the td-drag-check but with all the same hooks. We have no instances of the c-drag-handle option being used in the wild, and as it didn't seem to have any working examples, this component is replacing that one in the documentation.

![Screen Shot 2022-03-03 at 2 42 20 PM](https://user-images.githubusercontent.com/419899/156657571-1db6070c-324c-4586-a095-c6e5b2c1abef.png)

